### PR TITLE
 Fix bandit tool output comma handling

### DIFF
--- a/statick_tool/plugins/tool/bandit_tool_plugin.py
+++ b/statick_tool/plugins/tool/bandit_tool_plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 import csv
+
 import subprocess
 import shlex
 
@@ -65,36 +66,31 @@ class BanditToolPlugin(ToolPlugin):
         with open(self.get_name() + ".log", "w") as f:
             f.write(output)
 
-        issues = self.parse_output()
+        issues = self.parse_output(output.split('\n'))
         return issues
 
-    def parse_output(self):
+    def parse_output(self, output):
         """Parse tool output and report issues."""
         issues = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
-        try:
-            with open('bandit_results.csv', 'r') as csvfile:
-                csvreader = csv.reader(csvfile, quoting=csv.QUOTE_MINIMAL)
-                for line in csvreader:
-                    if len(line) < 7:
-                        continue
-                    if line[0] == 'filename':
-                        # Skip the column header line
-                        continue
-                    cert_reference = None
-                    if line[1] in warnings_mapping.keys():
-                        cert_reference = warnings_mapping[line[1]]
-                    severity = 1
-                    if line[4] == "MEDIUM":
-                        severity = 3
-                    elif line[4] == "HIGH":
-                        severity = 5
-                    issues.append(Issue(line[0], line[5],
-                                        self.get_name(), line[1],
-                                        severity, line[4], cert_reference))
-        except IOError:
-            # We couldn't find the results file for some reason
-            pass
+        for line in output:
+            line_data = line.split(',')
+            if len(line_data) < 7:
+                continue
+            if line_data[0] == 'filename':
+                # Skip the column header line
+                continue
+            cert_reference = None
+            if line_data[1] in warnings_mapping.keys():
+                cert_reference = warnings_mapping[line[1]]
+            severity = '1'
+            if line_data[4] == "MEDIUM":
+                severity = '3'
+            elif line_data[4] == "HIGH":
+                severity = '5'
+            issues.append(Issue(line_data[0], line_data[6],
+                                self.get_name(), line_data[2],
+                                severity, line_data[5], cert_reference))
 
         return issues

--- a/statick_tool/plugins/tool/bandit_tool_plugin.py
+++ b/statick_tool/plugins/tool/bandit_tool_plugin.py
@@ -74,23 +74,20 @@ class BanditToolPlugin(ToolPlugin):
         issues = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
-        for line in output:
-            line_data = line.split(',')
-            if len(line_data) < 7:
-                continue
-            if line_data[0] == 'filename':
-                # Skip the column header line
-                continue
+        output_minus_log = list(filter(lambda a: not a.startswith("[main]"),
+                                       output))
+        csvreader = csv.DictReader(output_minus_log)
+        for line in csvreader:
             cert_reference = None
-            if line_data[1] in warnings_mapping.keys():
-                cert_reference = warnings_mapping[line[1]]
+            if line['test_id'] in warnings_mapping.keys():
+                cert_reference = warnings_mapping[line['test_id']]
             severity = '1'
-            if line_data[4] == "MEDIUM":
+            if line['issue_confidence'] == "MEDIUM":
                 severity = '3'
-            elif line_data[4] == "HIGH":
+            elif line['issue_confidence'] == "HIGH":
                 severity = '5'
-            issues.append(Issue(line_data[0], line_data[6],
-                                self.get_name(), line_data[2],
-                                severity, line_data[5], cert_reference))
+            issues.append(Issue(line['filename'], line['line_number'],
+                                self.get_name(), line['test_id'],
+                                severity, line['issue_text'], cert_reference))
 
         return issues

--- a/statick_tool/plugins/tool/bandit_tool_plugin.py
+++ b/statick_tool/plugins/tool/bandit_tool_plugin.py
@@ -74,8 +74,19 @@ class BanditToolPlugin(ToolPlugin):
         issues = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
-        output_minus_log = list(filter(lambda a: not a.startswith("[main]"),
-                                       output))
+
+        # Copy output for modification
+        output_minus_log = list(output)
+
+        # Bandit prints a bunch of log messages out and you can't suppress
+        # them, so iterate over the list until we find the CSV header
+        for line in output:  # Intentionally output, not output_minus_log
+            if line.startswith('filename'):
+                # Found the CSV header, stop removing things
+                break
+            else:
+                output_minus_log.remove(line)
+
         csvreader = csv.DictReader(output_minus_log)
         for line in csvreader:
             cert_reference = None


### PR DESCRIPTION
Two changes:
* Changes bandit's output parsing to take a list of strings like other tools (this helps the tests I'm developing by providing an easily-tested parsing function)
* Use the CSV library to parse bandit output. Previously we were splitting on commas, but during testing at SoarTech we discovered that some issue descriptions can contain commas and break that parsing. The output properly quotes those elements of the output, so we might as well just use the CSV library.

Fixes #36.