### PR TITLE
Fixes to dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get update
     # Some desired apt packages are not available in Ubuntu 14.04 (Travis).
     # - cat install.txt | xargs sudo apt-get install -y
-  - sudo apt-get install -y clang-3.9 clang-format-3.9 clang-tidy-3.9 flawfinder libxml2-utils pylint python-git python-yapsy findbugs
+  - sudo apt-get install -y clang-3.9 clang-format-3.9 clang-tidy-3.9 flawfinder libxml2-utils pylint findbugs
   - sudo pip install statick
   - sudo pip install -r requirements.txt
   - sudo pip install -r requirements-docs.txt

--- a/install.txt
+++ b/install.txt
@@ -1,6 +1,7 @@
 clang-3.9
 clang-format-3.9
 clang-tidy-3.9
+findbugs
 flawfinder
 libomp-dev
 libxml2

--- a/install.txt
+++ b/install.txt
@@ -1,4 +1,3 @@
-bandit
 clang-3.9
 clang-format-3.9
 clang-tidy-3.9
@@ -7,5 +6,4 @@ libomp-dev
 libxml2
 libxml2-utils
 pylint
-python-git
 uncrustify

--- a/install.txt
+++ b/install.txt
@@ -8,5 +8,4 @@ libxml2
 libxml2-utils
 pylint
 python-git
-python-yapsy
 uncrustify

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydocstyle
 pyflakes
 pylint-django<2.0
 yamllint
+yapsy

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=['bandit', 'cmakelint', 'lizard', 'pycodestyle',
-                      'pydocstyle', 'pyflakes', 'yamllint'],
+                      'pydocstyle', 'pyflakes', 'yamllint', 'yapsy'],
     url='https://github.com/sscpac/statick',
     classifiers=[
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",


### PR DESCRIPTION
Move yapsy to setup.py (so that statick will run out of the box from pip install), remove duplicated bandit requirement, remove unused python-git requirement. Changes released under CC0 as usual.