### PR TITLE
Adding a check in the exceptions module to ensure the issue to be ign…

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -183,6 +183,8 @@ There are two types of exceptions.
 The `tools` key can either be `all` to suppress warnings from all tools or a list of specific tools.
 The `globs` key is a list of globs of files to ignore.
 The glob could also be a specific filename.
+For an exception to be applied to a specific issue, it is required that the issue contain an absolute path to the filename.
+The path for the issue is set in the tool plugin that generates the issues.
 
 `message_regex` exceptions ignore warnings based on a regular expression match against an error message.
 The `tools` key can either be `all` to suppress warnings from all tools or a list of specific tools.

--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -1,4 +1,16 @@
-"""Exceptions interface."""
+"""
+Exceptions interface.
+
+Exceptions allow for ignoring detected issues. This is commonly done to
+suppress false positives or to ignore issues that a group has no intention
+of addressing.
+
+The two types of exceptions are a list of filenames or regular expressions.
+If using filename matching for the exception it is required that the
+reported issue contain the absolute path to the file containing the issue
+to be ignored. The path for the issue is set in the tool plugin that
+generates the issues.
+"""
 
 import os
 import fnmatch
@@ -7,11 +19,7 @@ import yaml
 
 
 class Exceptions(object):
-    """
-    Manages which plugins are run for each statick scan level.
-
-    Sets what flags are used for each plugin at those levels.
-    """
+    """Interface for applying exceptions."""
 
     def __init__(self, filename):
         """Initialize exceptions interface."""
@@ -57,6 +65,8 @@ class Exceptions(object):
         for tool, tool_issues in issues.iteritems():
             to_remove = []
             for issue in tool_issues:
+                if not os.path.isabs(issue.filename):
+                    continue
                 rel_path = os.path.relpath(issue.filename, package.path)
                 for exception in exceptions:
                     if exception["tools"] == 'all' or tool in exception["tools"]:
@@ -98,6 +108,8 @@ class Exceptions(object):
         for tool, tool_issues in issues.iteritems():
             to_remove = []
             for issue in tool_issues:
+                if not os.path.isabs(issue.filename):
+                    continue
                 lines = open(issue.filename, "r").readlines()
                 line_number = int(issue.line_number)-1
                 if line_number < len(lines) and "NOLINT" in lines[line_number]:

--- a/statick_tool/plugins/tool/findbugs_tool_plugin.py
+++ b/statick_tool/plugins/tool/findbugs_tool_plugin.py
@@ -34,7 +34,8 @@ class FindbugsToolPlugin(ToolPlugin):
         if self.plugin_context.args.findbugs_bin is not None:
             findbugs_bin = self.plugin_context.args.findbugs_bin
 
-        flags = ["-textui", "-effort:max", "-dontCombineWarnings", "-longBugCodes", "-low"]
+        flags = ["-textui", "-effort:max", "-dontCombineWarnings",
+                 "-longBugCodes", "-low"]
         user_flags = self.plugin_context.config.get_tool_config(self.get_name(),
                                                                 level, "flags")
         lex = shlex.shlex(user_flags, posix=True)


### PR DESCRIPTION
…ored has an absolute path to the filename containing the issue. Documentation in the source code and users guide was updated to make it more clear that file exceptions require an absolute path to the issue filename.

@creffett. I think this is the minimum of what you wanted to see. Let me know if you want more changes for this initial pass at addressing exceptions for findbugs.