### PR TITLE
Use tox for code checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ dist/
 *.egg-info/
 
 docs/_build
+
+# From tests
+.coverage
+.pytest_cache
+.tox

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ docs/_build
 .coverage
 .pytest_cache
 .tox
+output-*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
     - python: 2.7
       env:
         - TOX_ENV=py27
-    - python: 3.5
-      env:
-        - TOX_ENV=py35
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 language: python
 python:
   - '2.7'
+
 cache:
   - apt
 
@@ -13,30 +14,27 @@ notifications:
 before_install:
   - sudo apt-get update
   - cat install.txt | xargs sudo apt-get install -y
-  - sudo pip install -r requirements-docs.txt
-  - sudo pip install tox
-
 
 matrix:
   include:
     - python: 2.7
-      env:
-        - TOX_ENV=py27
+      env: TOX_ENV=py27
 
 jobs:
   include:
     - stage: test
-      script:
-        - tox -e $TOX_ENV
-      script:
-        - mkdir statick_output; ./statick . statick_output --profile self_check.yaml
+      install: pip install tox
+      script: tox -e $TOX_ENV
+      script: mkdir statick_output; ./statick . statick_output --profile self_check.yaml
       # Force this to only run for one Python version
     - stage: build
       python: 2.7
+      install: pip install -r requirements-docs.txt
       script:
         - travis-sphinx build
     - stage: deploy
       # Force this to only run for one Python version
       python: 2.7
+      install: pip install -r requirements-docs.txt
       script:
         - travis-sphinx deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language:
   - generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 cache:
   - apt
+  - pip
 
 notifications:
   email:
@@ -15,16 +16,12 @@ before_install:
   - sudo apt-get update
   - cat install.txt | xargs sudo apt-get install -y
 
-matrix:
-  include:
-    - python: '2.7'
-      env: TOX_ENV=py27
-
 jobs:
   include:
     - stage: test
       install: pip install tox
-      script: tox -e $TOX_ENV
+      # Borrowed from flask-mongoengine
+      script: tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d . | sed -e 's/pypypy/pypy/')
       # This adds a second parallel "test" stage (since we didn't specify
       # the stage name)
     - install: pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 dist: xenial
 sudo: required
-language:
-  - generic
+language: python
+python:
+  - '2.7'
 cache:
   - apt
 
@@ -27,8 +28,8 @@ jobs:
     - stage: test
       script:
         - tox -e $TOX_ENV
-        - mkdir statick_output
-        - ./statick . statick_output --profile self_check.yaml
+      script:
+        - mkdir statick_output; ./statick . statick_output --profile self_check.yaml
       # Force this to only run for one Python version
     - stage: build
       python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 
 matrix:
   include:
-    - python: 2.7
+    - python: '2.7'
       env: TOX_ENV=py27
 
 jobs:
@@ -31,13 +31,13 @@ jobs:
       script: mkdir statick_output; ./statick . statick_output --profile self_check.yaml
       # Force this to only run for one Python version
     - stage: build
-      python: 2.7
+      python: '2.7'
       install: pip install -r requirements-docs.txt
       script:
         - travis-sphinx build
     - stage: deploy
       # Force this to only run for one Python version
-      python: 2.7
+      python: '2.7'
       install: pip install -r requirements-docs.txt
       script:
         - travis-sphinx deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ notifications:
 
 before_install:
   - sudo apt-get update
-    # Some desired apt packages are not available in Ubuntu 14.04 (Travis).
-    # - cat install.txt | xargs sudo apt-get install -y
-  - sudo apt-get install -y clang-3.9 clang-format-3.9 clang-tidy-3.9 flawfinder libxml2-utils pylint findbugs
+  - cat install.txt | xargs sudo apt-get install -y
   - sudo pip install statick
   - sudo pip install -r requirements.txt
   - sudo pip install -r requirements-docs.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,9 @@ jobs:
       # Force this to only run for one Python version
     - stage: build
       python: '2.7'
-      install: pip install -r requirements-docs.txt
+      install:
+        - pip install -r requirements.txt
+        - pip install -r requirements-docs.txt
       script:
         - travis-sphinx build
-    - stage: deploy
-      # Force this to only run for one Python version
-      python: '2.7'
-      install: pip install -r requirements-docs.txt
-      script:
         - travis-sphinx deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jobs:
     - stage: test
       install: pip install tox
       script: tox -e $TOX_ENV
+      # This adds a second parallel "test" stage (since we didn't specify
+      # the stage name)
+    - install: pip install -r requirements.txt
       script: mkdir statick_output; ./statick . statick_output --profile self_check.yaml
       # Force this to only run for one Python version
     - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ notifications:
 before_install:
   - sudo apt-get update
   - cat install.txt | xargs sudo apt-get install -y
-  - sudo pip install statick
-  - sudo pip install -r requirements.txt
   - sudo pip install -r requirements-docs.txt
   - sudo pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,32 @@ before_install:
   - sudo pip install statick
   - sudo pip install -r requirements.txt
   - sudo pip install -r requirements-docs.txt
+  - sudo pip install tox
 
-script:
-  - mkdir statick_output
-  - ./statick . statick_output --profile self_check.yaml
-  - travis-sphinx build
-    
-after_success:
-  - travis-sphinx deploy
+
+matrix:
+  include:
+    - python: 2.7
+      env:
+        - TOX_ENV=py27
+    - python: 3.5
+      env:
+        - TOX_ENV=py35
+
+jobs:
+  include:
+    - stage: test
+      script:
+        - tox -e $TOX_ENV
+        - mkdir statick_output
+        - ./statick . statick_output --profile self_check.yaml
+      # Force this to only run for one Python version
+    - stage: build
+      python: 2.7
+      script:
+        - travis-sphinx build
+    - stage: deploy
+      # Force this to only run for one Python version
+      python: 2.7
+      script:
+        - travis-sphinx deploy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../../'))
 
 # -- Project information -----------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 try:
     from setuptools import setup
-except:  # pylint: disable=bare-except
+except:  # pylint: disable=bare-except # noqa: E722
     from distutils.core import setup  # pylint: disable=wrong-import-order
 
 import statick_tool

--- a/statick
+++ b/statick
@@ -4,6 +4,7 @@ Executable script for running statick against a single package.
 """
 
 import sys
+
 from statick_tool.args import Args
 from statick_tool.statick import Statick
 

--- a/statick_tool/args.py
+++ b/statick_tool/args.py
@@ -4,6 +4,7 @@ Custom argument handling.
 Enable usage of user-paths argument before parsing other arguments.
 """
 from __future__ import print_function
+
 import argparse
 import os
 

--- a/statick_tool/config.py
+++ b/statick_tool/config.py
@@ -4,6 +4,7 @@ Manages which plugins are run for each statick scan level.
 Sets what flags are used for each plugin at those levels.
 """
 from collections import OrderedDict
+
 import yaml
 
 

--- a/statick_tool/config.py
+++ b/statick_tool/config.py
@@ -43,7 +43,7 @@ class Config(object):
         """Get what discovery plugins are enabled for a certain level."""
         return self.get_enabled_plugins(level, "discovery")
 
-    def get_plugin_config(self, plugin_type, plugin, level, key, default=None):  #pylint: disable=too-many-arguments
+    def get_plugin_config(self, plugin_type, plugin, level, key, default=None):  # pylint: disable=too-many-arguments
         """Get flags to use for a plugin at a certain level."""
         level_config = self.config["levels"][level]
         if plugin_type in level_config:

--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -112,7 +112,7 @@ class Exceptions(object):
                     self.print_exception_warning(tool)
                     continue
                 lines = open(issue.filename, "r").readlines()
-                line_number = int(issue.line_number)-1
+                line_number = int(issue.line_number) - 1
                 if line_number < len(lines) and "NOLINT" in lines[line_number]:
                     to_remove.append(issue)
             issues[tool] = [issue for issue in tool_issues if issue not in to_remove]

--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -12,9 +12,10 @@ to be ignored. The path for the issue is set in the tool plugin that
 generates the issues.
 """
 
-import os
 import fnmatch
+import os
 import re
+
 import yaml
 
 

--- a/statick_tool/gauntlet.py
+++ b/statick_tool/gauntlet.py
@@ -6,11 +6,12 @@ This file is a huge mess right now since it's ported pretty directly
 from the old version of the tool.
 """
 
-import subprocess
-import os
-import sys
-import re
 import fnmatch
+import os
+import re
+import subprocess
+import sys
+
 import yaml
 
 from statick_tool.args import Args

--- a/statick_tool/gauntlet.py
+++ b/statick_tool/gauntlet.py
@@ -53,7 +53,7 @@ def main():  # pylint: disable=too-many-locals, too-many-branches, too-many-stat
     if "CMakeCache.txt" not in out_files or parsed_args.force_cmake:
         print "Running CMake..."
         try:
-            _ = subprocess.check_output(["cmake", src_path, "-B" + out_path])
+            subprocess.check_output(["cmake", src_path, "-B" + out_path])
         except subprocess.CalledProcessError as exc:
             print "CMake FAILED!"
             print exc.output
@@ -70,7 +70,7 @@ def main():  # pylint: disable=too-many-locals, too-many-branches, too-many-stat
             target_re = r"^([a-zA-Z0-9][^$#\/\t=]*):([^=]|$)"
             target_rec = re.compile(target_re)
             try:
-                _ = subprocess.check_output(["make", "-qp"], cwd=out_path)  # NOLINT
+                subprocess.check_output(["make", "-qp"], cwd=out_path)  # NOLINT
             except subprocess.CalledProcessError as exc:
                 for line in exc.output.split("\n"):
                     match = target_rec.match(line)

--- a/statick_tool/plugins/discovery/c_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/c_discovery_plugin.py
@@ -1,6 +1,7 @@
 """Discover C files to analyze."""
 
 from __future__ import print_function
+
 import os
 import subprocess
 from collections import OrderedDict

--- a/statick_tool/plugins/discovery/catkin_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/catkin_discovery_plugin.py
@@ -1,6 +1,7 @@
 """Discovery plugin to find catkin packages."""
 
 from __future__ import print_function
+
 import os
 
 from statick_tool.discovery_plugin import DiscoveryPlugin

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -90,8 +90,8 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
                 include_dirs = match.group(3).split(";")
                 src = [src for src in match.group(4).split(";")
                        if not qt_p.match(src)]
-                src = [src if os.path.isabs(src)
-                       else os.path.join(src_dir, src) for src in src]  # NOLINT
+                src = [src if os.path.isabs(src)  # noqa F812
+                       else os.path.join(src_dir, src) for src in src]  # NOLINT  # noqa F812
 
                 target = {"name": name, "src_dir": src_dir,
                           "include_dirs": include_dirs, "src": src}

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -68,15 +68,13 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
     def process_output(cls, output, package):
         """Parse the tool output."""
 # pylint: disable=anomalous-backslash-in-string
-        cmake_target_re = r"""-- TARGET: \[NAME:(.+)\]
-\[SRC_DIR:(.+)\]\[INCLUDE_DIRS:(.+)\]\[SRC:(.+)\]"""  # NOQA: W605
+        cmake_target_re = r"-- TARGET: \[NAME:(.+)\]\[SRC_DIR:(.+)\]\[INCLUDE_DIRS:(.+)\]\[SRC:(.+)\]"  # NOQA: W605
         target_p = re.compile(cmake_target_re)
         cmake_headers_re = r"-- HEADERS: (.+)"
         headers_p = re.compile(cmake_headers_re)
         cmake_roslint_re = r"-- ROSLINT: (.+)"
         roslint_p = re.compile(cmake_roslint_re)
-        cmake_project_re = r"""-- PROJECT: \[NAME:(.+)\]
-\[SRC_DIR:(.+)\]\[BIN_DIR:(.+)\]"""  # NOQA: W605
+        cmake_project_re = r"-- PROJECT: \[NAME:(.+)\]\[SRC_DIR:(.+)\]\[BIN_DIR:(.+)\]"  # NOQA: W605
         project_p = re.compile(cmake_project_re)
 # pylint: enable=anomalous-backslash-in-string
 

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -1,10 +1,11 @@
 """Discovery plugin to find CMake-based projects."""
 
 from __future__ import print_function
+
 import os
+import re
 import shutil
 import subprocess
-import re
 
 from statick_tool.discovery_plugin import DiscoveryPlugin
 

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -52,7 +52,7 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
                   format(str(ex.returncode)))
             print("{}".format(ex.output))
 
-        except OSError as ex:
+        except OSError:
             print("Couldn't find cmake executable!")
             return None
 
@@ -68,15 +68,15 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
     def process_output(cls, output, package):
         """Parse the tool output."""
 # pylint: disable=anomalous-backslash-in-string
-        cmake_target_re = r"-- TARGET: \[NAME:(.+)\]" \
-                          "\[SRC_DIR:(.+)\]\[INCLUDE_DIRS:(.+)\]\[SRC:(.+)\]"
+        cmake_target_re = r"""-- TARGET: \[NAME:(.+)\]
+\[SRC_DIR:(.+)\]\[INCLUDE_DIRS:(.+)\]\[SRC:(.+)\]"""  # NOQA: W605
         target_p = re.compile(cmake_target_re)
         cmake_headers_re = r"-- HEADERS: (.+)"
         headers_p = re.compile(cmake_headers_re)
         cmake_roslint_re = r"-- ROSLINT: (.+)"
         roslint_p = re.compile(cmake_roslint_re)
-        cmake_project_re = r"-- PROJECT: \[NAME:(.+)\]" \
-                           "\[SRC_DIR:(.+)\]\[BIN_DIR:(.+)\]"
+        cmake_project_re = r"""-- PROJECT: \[NAME:(.+)\]
+\[SRC_DIR:(.+)\]\[BIN_DIR:(.+)\]"""  # NOQA: W605
         project_p = re.compile(cmake_project_re)
 # pylint: enable=anomalous-backslash-in-string
 

--- a/statick_tool/plugins/discovery/java_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/java_discovery_plugin.py
@@ -1,8 +1,9 @@
 """Discover Java files to analyze."""
 
 from __future__ import print_function
-import os
+
 import fnmatch
+import os
 from collections import OrderedDict
 
 from statick_tool.discovery_plugin import DiscoveryPlugin

--- a/statick_tool/plugins/discovery/python_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/python_discovery_plugin.py
@@ -1,8 +1,9 @@
 """Discover python files to analyze."""
 
 from __future__ import print_function
-import os
+
 import fnmatch
+import os
 import subprocess
 from collections import OrderedDict
 

--- a/statick_tool/plugins/discovery/xml_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/xml_discovery_plugin.py
@@ -1,8 +1,9 @@
 """Discover XML files to analyze."""
 
 from __future__ import print_function
-import os
+
 import fnmatch
+import os
 from collections import OrderedDict
 
 from statick_tool.discovery_plugin import DiscoveryPlugin

--- a/statick_tool/plugins/discovery/yaml_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/yaml_discovery_plugin.py
@@ -1,8 +1,9 @@
 """Discover YAML files to analyze."""
 
 from __future__ import print_function
-import os
+
 import fnmatch
+import os
 from collections import OrderedDict
 
 from statick_tool.discovery_plugin import DiscoveryPlugin

--- a/statick_tool/plugins/tool/bandit_tool_plugin.py
+++ b/statick_tool/plugins/tool/bandit_tool_plugin.py
@@ -1,13 +1,13 @@
 """Apply bandit tool and gather results."""
 
 from __future__ import print_function
+
 import csv
-
-import subprocess
 import shlex
+import subprocess
 
-from statick_tool.tool_plugin import ToolPlugin
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class BanditToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
+++ b/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
@@ -1,13 +1,14 @@
 """Apply catkin_lint tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
-import os
 
-from statick_tool.tool_plugin import ToolPlugin
+import os
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class CatkinLintToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
+++ b/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
@@ -58,7 +58,7 @@ class CatkinLintToolPlugin(ToolPlugin):
         """Manual exceptions."""
         message = match.group(5)
         norm_path = os.path.normpath(package.path + "/" + match.group(2))
-        line = open(norm_path, "r").readlines()[int(match.group(3))-1].strip()
+        line = open(norm_path, "r").readlines()[int(match.group(3)) - 1].strip()
 
         # There are a few cases where this is ok.
         if message == "variable CMAKE_CXX_FLAGS is modified":

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -1,13 +1,14 @@
 """Apply clang-format tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
-import difflib
 
-from statick_tool.tool_plugin import ToolPlugin
+import difflib
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class ClangFormatToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -42,8 +42,8 @@ class ClangFormatToolPlugin(ToolPlugin):
         if self.plugin_context.args.clang_format_bin is not None:
             clang_format_bin = self.plugin_context.args.clang_format_bin
 
-        flags = ["-header-filter="+package["src_dir"]+"/.*", "-p",
-                 package["bin_dir"]+"/compile_commands.json"]
+        flags = ["-header-filter=" + package["src_dir"] + "/.*", "-p",
+                 package["bin_dir"] + "/compile_commands.json"]
         user_flags = self.plugin_context.config.get_tool_config(self.get_name(),
                                                                 level, "flags")
         lex = shlex.shlex(user_flags, posix=True)
@@ -72,7 +72,7 @@ class ClangFormatToolPlugin(ToolPlugin):
                 if line.startswith("+ ") or line.startswith("- ") or \
                    line.startswith("! "):
                     if line[2:].strip()[0] != "#":
-# pylint: disable=line-too-long
+                        # pylint: disable=line-too-long
                         exc = subprocess.CalledProcessError(-1,
                                                             clang_format_bin,
                                                             ".clang-format style is not correct. There is one located in {}. Put this file in your home directory.".

--- a/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
@@ -35,8 +35,8 @@ class ClangTidyToolPlugin(ToolPlugin):
         if self.plugin_context.args.clang_tidy_bin is not None:
             clang_tidy_bin = self.plugin_context.args.clang_tidy_bin
 
-        flags = ["-header-filter="+package["src_dir"]+"/.*", "-p",
-                 package["bin_dir"]+"/compile_commands.json",
+        flags = ["-header-filter=" + package["src_dir"] + "/.*", "-p",
+                 package["bin_dir"] + "/compile_commands.json",
                  "-extra-arg=-fopenmp=libomp"]
         user_flags = self.plugin_context.config.get_tool_config(self.get_name(),
                                                                 level, "flags")

--- a/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply clang-tidy tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class ClangTidyToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/cmakelint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cmakelint_tool_plugin.py
@@ -1,13 +1,14 @@
 """Apply cmakelint tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
-import os
 
-from statick_tool.tool_plugin import ToolPlugin
+import os
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class CMakelintToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/cppcheck_tool_plugin.py
+++ b/statick_tool/plugins/tool/cppcheck_tool_plugin.py
@@ -1,13 +1,14 @@
 """Apply cppcheck tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
-import os
 
-from statick_tool.tool_plugin import ToolPlugin
+import os
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class CppcheckToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/cpplint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cpplint_tool_plugin.py
@@ -1,13 +1,14 @@
 """Apply Cpplint tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
-import os
 
-from statick_tool.tool_plugin import ToolPlugin
+import os
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class CpplintToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/findbugs_tool_plugin.py
+++ b/statick_tool/plugins/tool/findbugs_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply findbugs tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class FindbugsToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/flawfinder_tool_plugin.py
+++ b/statick_tool/plugins/tool/flawfinder_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply flawfinder tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class FlawfinderToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/lizard_tool_plugin.py
+++ b/statick_tool/plugins/tool/lizard_tool_plugin.py
@@ -1,11 +1,12 @@
 """Apply lizard tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class LizardToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/make_tool_plugin.py
+++ b/statick_tool/plugins/tool/make_tool_plugin.py
@@ -58,7 +58,7 @@ class MakeToolPlugin(ToolPlugin):
         while i < len(matches):
             cur_match = matches[i]
             if "overloaded-virtual" in cur_match[4] and i + 1 < len(matches):
-                next_match = matches[i+1]
+                next_match = matches[i + 1]
                 if next_match[0].startswith(package.path):
                     result.append((next_match[0], next_match[1], next_match[2],
                                    cur_match[3], cur_match[4] + next_match[4]))

--- a/statick_tool/plugins/tool/make_tool_plugin.py
+++ b/statick_tool/plugins/tool/make_tool_plugin.py
@@ -1,11 +1,12 @@
 """Apply make tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class MakeToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply pycodestyle tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class PycodestyleToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply pydocstyle tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class PydocstyleToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/pyflakes_tool_plugin.py
+++ b/statick_tool/plugins/tool/pyflakes_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply pyflakes tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class PyflakesToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/pylint_tool_plugin.py
+++ b/statick_tool/plugins/tool/pylint_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply pylint tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class PylintToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/uncrustify_tool_plugin.py
+++ b/statick_tool/plugins/tool/uncrustify_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply uncrustify tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import difflib
 
-from statick_tool.tool_plugin import ToolPlugin
+import difflib
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class UncrustifyToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/xmllint_tool_plugin.py
+++ b/statick_tool/plugins/tool/xmllint_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply xmllint tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class XmllintToolPlugin(ToolPlugin):

--- a/statick_tool/plugins/tool/yamllint_tool_plugin.py
+++ b/statick_tool/plugins/tool/yamllint_tool_plugin.py
@@ -1,12 +1,13 @@
 """Apply yamllint tool and gather results."""
 
 from __future__ import print_function
-import subprocess
-import shlex
-import re
 
-from statick_tool.tool_plugin import ToolPlugin
+import re
+import shlex
+import subprocess
+
 from statick_tool.issue import Issue
+from statick_tool.tool_plugin import ToolPlugin
 
 
 class YamllintToolPlugin(ToolPlugin):

--- a/statick_tool/profile.py
+++ b/statick_tool/profile.py
@@ -2,6 +2,7 @@
 
 import yaml
 
+
 class Profile(object):  # pylint: disable=too-few-public-methods
     """Manages which scan levels are run for packages."""
 

--- a/statick_tool/report.py
+++ b/statick_tool/report.py
@@ -1,6 +1,7 @@
 """Write issue reports to screen and file."""
 
 from __future__ import print_function
+
 from collections import OrderedDict
 
 

--- a/statick_tool/resources.py
+++ b/statick_tool/resources.py
@@ -5,6 +5,7 @@ Handles chainging user directories and the default statick resource directory.
 """
 
 from __future__ import print_function
+
 import os
 
 

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -38,12 +38,12 @@ class Statick(object):
         self.discovery_plugins = {}
         for plugin_info in self.manager.getPluginsOfCategory("Discovery"):
             self.discovery_plugins[plugin_info.plugin_object.get_name()] = \
-                    plugin_info.plugin_object
+                plugin_info.plugin_object
 
         self.tool_plugins = {}
         for plugin_info in self.manager.getPluginsOfCategory("Tool"):
             self.tool_plugins[plugin_info.plugin_object.get_name()] = \
-                    plugin_info.plugin_object
+                plugin_info.plugin_object
 
         self.config = Config(self.resources.get_file("config.yaml"))
 

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -1,21 +1,23 @@
 """Code analysis front-end."""
 
 from __future__ import print_function
+
 import copy
-import os
 import logging
+import os
 
 from yapsy.PluginManager import PluginManager
+
 from statick_tool import __version__
-from statick_tool.package import Package
-from statick_tool.discovery_plugin import DiscoveryPlugin
-from statick_tool.tool_plugin import ToolPlugin
-from statick_tool.report import generate_report
-from statick_tool.exceptions import Exceptions
 from statick_tool.config import Config
-from statick_tool.profile import Profile
-from statick_tool.resources import Resources
+from statick_tool.discovery_plugin import DiscoveryPlugin
+from statick_tool.exceptions import Exceptions
+from statick_tool.package import Package
 from statick_tool.plugin_context import PluginContext
+from statick_tool.profile import Profile
+from statick_tool.report import generate_report
+from statick_tool.resources import Resources
+from statick_tool.tool_plugin import ToolPlugin
 
 logging.basicConfig()
 

--- a/statick_ws
+++ b/statick_ws
@@ -3,11 +3,12 @@
 Executable script for running statick against a workspace.
 """
 
-import sys
 import os
+import sys
+
 from statick_tool.args import Args
-from statick_tool.statick import Statick
 from statick_tool.report import generate_report
+from statick_tool.statick import Statick
 
 
 def main():  # pylint: disable=too-many-locals, too-many-branches, too-many-statements

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ flake8-max-line-length=9000
 exclude = .tox
 
 [testenv]
+changedir = {toxinidir}/output-{envname}
 deps =
     pytest
     pytest-cov
@@ -15,5 +16,6 @@ deps =
     pytest-isort
     pytest-pep257
 commands =
-    pytest --flake8 --pep257 --isort --cov=statick_tool --doctest-modules \
-        --junit-xml=statick-{envname}-junit.xml --junit-prefix={envname}
+    pytest --flake8 --pep257 --isort --cov={toxinidir}/statick_tool \
+        --doctest-modules --junit-xml=statick-{envname}-junit.xml \
+        --junit-prefix={envname} {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py27
+skip_missing_interpreters=true
 
 [pytest]
 flake8-max-line-length=9000

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 envlist = py27
 
+[pytest]
+flake8-max-line-length=9000
+
 [testenv]
 deps =
-    flake8
     pytest
     pytest-cov
+    pytest-flake8
+    pytest-isort
+    pytest-pep257
 commands =
-    flake8 --ignore=E501
-    pytest --cov
+    pytest --flake8 --pep257 --isort --cov

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27
 
 [pytest]
 flake8-max-line-length=9000
+norecursedirs = .tox docs examples
 
 [flake8]
 exclude = .tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps =
+    flake8
+    pytest
+    pytest-cov
+commands =
+    flake8 --ignore=E501
+    pytest --cov

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ envlist = py27
 [pytest]
 flake8-max-line-length=9000
 
+[flake8]
+exclude = .tox
+
 [testenv]
 deps =
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,5 @@ deps =
     pytest-isort
     pytest-pep257
 commands =
-    pytest --flake8 --pep257 --isort --cov
+    pytest --flake8 --pep257 --isort --cov=statick_tool --doctest-modules \
+        --junit-xml=statick-{envname}-junit.xml --junit-prefix={envname}


### PR DESCRIPTION
Most of these changes are things like import order sorting or pep8 cleanups so that the tox tests actually pass. I went with the following pytest plugins:
* pytest-cov
* pytest-flake8
* pytest-isort
* pytest-pep257

If there are any you don't like in there, I'm fine with changing that list, it was just based on the plugins I've used on other projects. Reason we're using tox + pytest is to lay the ground work for actual unit testing and multi-python tests in the future.