### PR TITLE
Travis deploy to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,11 @@ script:
     
 after_success:
   - travis-sphinx deploy
+
+deploy:
+  provider: pypi
+  user: tdenewiler
+  password:
+    secure: t4ewjCNq1cFlWrdz+dapN1FlGSi7HHZVlErDuVFJuVFeuBxcVOyDLoRhbcZsX4/bAirM5DAWKfR+MiucZ/Ut8D0r3YFjvyaf9FfnXlKCt0Z3V/FxwADsy489dDjY7M7H+2563k4NyR03rXO/0qsU/An1fROv0buycLA2+PwuYPUeM0eRwuYPgSDyL+84AYPHVqwU8p0VKw4Z58iGVzyzpy3tZN4jxne+bO8tXf+qj7lC1Oi53/kJvhG5XvdI8lIPZv6KyO4t7lNzrniS6+SbNQqFSYrJ0zh28iXhoA3iM0u2YbKvRcc2CduwQzykwzIMWlCRrvrRBsePpuDT4k9VDXeOaNbu5ZxLY87bZWsld/549itidtqjF1So8tcgdAS5aO1O6G4BqfXXIhBdRHKxiUrm2h28ubXq4eHvDjxXpE7YLMN2jiXptTXX5zVRo9gkCv4UPk/Ugsk2XQ234UByq3aQjgiFDreBh5SCqzEQtUgY10neoKsG0kigrAYMJH0xMxhr00mPXMWJI9dumGilSI/Cz1uQmXuMqBxXg2IwAfulBDG6rsYCHSw0mFJvFEqt5ifnyP9WtHozc3PHWY2+1RLlzCpEnezHyRWZ4HrcPSWUKdHy9INczOQ9U2G1MH1cXOgZ0+rnHMdtsg+mbo+Y/A9mbiVyLcxgznoE1fSsYI0=
+  on:
+    tags: true


### PR DESCRIPTION
Adding deploy section to Travis CI configuration. Now set to release to PyPI on new tags. Password is encrypted using Travis CI command line interface.