### PR TITLE
Temporary fix in tox.ini for flake8 breakage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ exclude = .tox
 [testenv]
 changedir = {toxinidir}/output-{envname}
 deps =
+# Temporary workaround while pytest-flake8 is broken with latest flake8, see https://github.com/tholo/pytest-flake8/issues/56
+    flake8==3.6.0
     pytest
     pytest-cov
     pytest-flake8


### PR DESCRIPTION
flake8 had an API change in 3.7.0 which broke pytest-flake8. 3.7.2 partially fixed it, but pytest-flake8 is still calling a no-longer-present method. This MR temporarily pins flake8 in tox to 3.6.0 pending pytest-flake8 getting a fix pushed (see https://github.com/tholo/pytest-flake8/issues/56)