### PR TITLE
Don't fail if `file` command is missing

### DIFF
--- a/statick_tool/discovery_plugin.py
+++ b/statick_tool/discovery_plugin.py
@@ -1,5 +1,7 @@
 """Discovery plugin."""
 import os
+import sys
+
 from yapsy.IPlugin import IPlugin
 
 
@@ -27,4 +29,14 @@ class DiscoveryPlugin(IPlugin):
     @staticmethod
     def file_command_exists():
         """Return whether the 'file' command is available on $PATH"""
-        return os.path.isfile('file') and os.access(fpath, os.X_OK)
+        if sys.platform == 'win32':
+            command_name = 'file.exe'
+        else:
+            command_name = 'file'
+
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_path = os.path.join(path, command_name)
+            if os.path.isfile(exe_path) and os.access(exe_path, os.X_OK):
+                return True
+
+        return False

--- a/statick_tool/discovery_plugin.py
+++ b/statick_tool/discovery_plugin.py
@@ -1,5 +1,5 @@
 """Discovery plugin."""
-
+import os
 from yapsy.IPlugin import IPlugin
 
 
@@ -23,3 +23,8 @@ class DiscoveryPlugin(IPlugin):
     def set_plugin_context(self, plugin_context):
         """Set the plugin context."""
         self.plugin_context = plugin_context
+
+    @staticmethod
+    def file_command_exists():
+        """Return whether the 'file' command is available on $PATH"""
+        return os.path.isfile('file') and os.access(fpath, os.X_OK)

--- a/statick_tool/plugins/discovery/c_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/c_discovery_plugin.py
@@ -20,13 +20,16 @@ class CDiscoveryPlugin(DiscoveryPlugin):
         """Scan package looking for C files."""
         c_files = []
         c_extensions = ('.c', '.cc', '.cpp', '.cxx', '.h', '.hxx', '.hpp')
+        file_cmd_exists = True
+        if not DiscoveryPlugin.file_command_exists():
+            file_cmd_exists = False
 
         for root, _, files in os.walk(package.path):
             for f in files:
                 if f.lower().endswith(c_extensions):
                     full_path = os.path.join(root, f)
                     c_files.append(os.path.abspath(full_path))
-                else:
+                elif file_cmd_exists:
                     full_path = os.path.join(root, f)
                     output = subprocess.check_output(["file", full_path], universal_newlines=True)
                     if ("c source" in output.lower() or

--- a/statick_tool/plugins/discovery/python_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/python_discovery_plugin.py
@@ -34,7 +34,7 @@ class PythonDiscoveryPlugin(DiscoveryPlugin):
                 for f in files:
                     full_path = os.path.join(root, f)
                     output = subprocess.check_output(["file", full_path],
-                                                 universal_newlines=True)
+                                                     universal_newlines=True)
                     if ("python script" in output or
                             "Python script" in output) and not \
                             f.endswith(".cfg"):

--- a/statick_tool/plugins/discovery/python_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/python_discovery_plugin.py
@@ -21,19 +21,24 @@ class PythonDiscoveryPlugin(DiscoveryPlugin):
         """Scan package looking for python files."""
         python_files = []
 
+        file_cmd_exists = True
+        if not DiscoveryPlugin.file_command_exists():
+            file_cmd_exists = False
+
         for root, _, files in os.walk(package.path):
             for f in fnmatch.filter(files, "*.py"):
                 full_path = os.path.join(root, f)
                 python_files.append(os.path.abspath(full_path))
 
-            for f in files:
-                full_path = os.path.join(root, f)
-                output = subprocess.check_output(["file", full_path],
+            if file_cmd_exists:
+                for f in files:
+                    full_path = os.path.join(root, f)
+                    output = subprocess.check_output(["file", full_path],
                                                  universal_newlines=True)
-                if ("python script" in output or
-                        "Python script" in output) and not \
-                        f.endswith(".cfg"):
-                    python_files.append(os.path.abspath(full_path))
+                    if ("python script" in output or
+                            "Python script" in output) and not \
+                            f.endswith(".cfg"):
+                        python_files.append(os.path.abspath(full_path))
 
         python_files = list(OrderedDict.fromkeys(python_files))
 

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -142,6 +142,9 @@ class Statick(object):
         plugin_context = PluginContext(args, self.resources, self.config)
 
         print("---Discovery---")
+        if not DiscoveryPlugin.file_command_exists():
+            print("file command isn't available, discovery plugins will be less effective")
+
         discovery_plugins = self.config.get_enabled_discovery_plugins(level)
         if len(discovery_plugins) == 0:
             discovery_plugins = list(self.discovery_plugins.keys())

--- a/tests/plugins/discovery/c_discovery_plugin/test_c_discovery_plugin.py
+++ b/tests/plugins/discovery/c_discovery_plugin/test_c_discovery_plugin.py
@@ -35,8 +35,9 @@ def test_c_discovery_plugin_scan_valid():
                                                     'valid_package'))
     cdp.scan(package, 'level')
     expected = ['test.c', 'test.cpp', 'test.cc', 'test.cxx', 'test.h',
-                'test.hxx', 'test.hpp', 'oddextensioncpp.source',
-                'oddextensionc.source']
+                'test.hxx', 'test.hpp']
+    if cdp.file_command_exists():
+        expected += ['oddextensioncpp.source', 'oddextensionc.source']
     # We have to add the path to each of the above...yuck
     expected_fullpath = [os.path.join(package.path, filename)
                          for filename in expected]
@@ -44,7 +45,7 @@ def test_c_discovery_plugin_scan_valid():
     assert set(package['c_src']) == set(expected_fullpath)
 
 
-def test_c_discovery_plugin_scan_invalid_nocmake():
+def test_c_discovery_plugin_scan_invalid():
     """Test that the C discovery plugin doesn't find non-C files."""
     cdp = CDiscoveryPlugin()
     package = Package('invalid_package',

--- a/tests/plugins/discovery/python_discovery_plugin/test_python_discovery_plugin.py
+++ b/tests/plugins/discovery/python_discovery_plugin/test_python_discovery_plugin.py
@@ -35,7 +35,9 @@ def test_python_discovery_plugin_scan_valid():
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
     pydp.scan(package, 'level')
-    expected = ['test.py', 'oddextensionpy.source']
+    expected = ['test.py']
+    if pydp.file_command_exists():
+        expected += ['oddextensionpy.source']
     # We have to add the path to each of the above...yuck
     expected_fullpath = [os.path.join(package.path, filename)
                          for filename in expected]


### PR DESCRIPTION
The Python and C plugins both use `file` to identify files with unusual extensions. This breaks on Windows Powershell, for example, which doesn't have that command available. This MR has the following changes:
* Adds a common function to discovery_plugin.py to test for the presence of `file`
* Prints a warning in statick.py if it's missing
* Skips the iterate-over-tree-run-file steps in the c and python discovery plugins if `file` isn't present
* Modifies the tests for those modules to change the expected list of detected files based on whether or not `file` is available.