### PR TITLE
Add tool_plugin command to check whether a command exists on PATH

### DIFF
--- a/statick_tool/tool_plugin.py
+++ b/statick_tool/tool_plugin.py
@@ -2,7 +2,9 @@
 
 from __future__ import print_function
 
+import os
 import shlex
+import sys
 
 from yapsy.IPlugin import IPlugin
 
@@ -62,3 +64,32 @@ class ToolPlugin(IPlugin):
             lex.whitespace_split = True
             flags = list(lex)
         return flags
+
+    @staticmethod
+    def is_valid_executable(path):
+        """Return whether a provided command exists and is executable."""
+        return os.path.isfile(path) and os.access(path, os.X_OK)
+
+    @staticmethod
+    def command_exists(command):
+        """Return whether a particular command is available on $PATH"""
+
+        if sys.platform == 'win32':
+            # Tack .exe on if the command doesn't have an extension
+            _, extension = os.path.splitext(command)
+            if not extension:
+                command += '.exe'
+
+        fpath, fname = os.path.split(command)
+
+        if fpath:
+            # Contains a path, not just a command, so don't search PATH
+            return ToolPlugin.is_valid_executable(command)
+
+        else:
+            for path in os.environ["PATH"].split(os.pathsep):
+                exe_path = os.path.join(path, command)
+                if os.path.isfile(exe_path) and os.access(exe_path, os.X_OK):
+                    return True
+
+        return False

--- a/statick_tool/tool_plugin.py
+++ b/statick_tool/tool_plugin.py
@@ -91,9 +91,8 @@ class ToolPlugin(IPlugin):
 
     @staticmethod
     def command_exists(command):
-        """Return whether a particular command is available on $PATH"""
-
-        fpath, fname = os.path.split(command)
+        """Return whether a particular command is available on $PATH."""
+        fpath, _ = os.path.split(command)
 
         if fpath:
             # Contains a path, not just a command, so don't search PATH

--- a/statick_tool/tool_plugin.py
+++ b/statick_tool/tool_plugin.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import os
 import shlex
-import sys
 
 from yapsy.IPlugin import IPlugin
 
@@ -67,18 +66,32 @@ class ToolPlugin(IPlugin):
 
     @staticmethod
     def is_valid_executable(path):
-        """Return whether a provided command exists and is executable."""
-        return os.path.isfile(path) and os.access(path, os.X_OK)
+        """
+        Return whether a provided command exists and is executable.
+
+        If the provided path has an extension on it, don't change it, otherwise
+        try adding common extensions.
+        """
+
+        # On Windows, PATHEXT contains a list of extensions which can be
+        # appended to a program name when searching PATH.
+        extensions = os.environ.get('PATHEXT', None)
+        _, path_ext = os.path.splitext(path)
+        if path_ext or not extensions:
+            return os.path.isfile(path) and os.access(path, os.X_OK)
+        else:
+            extensions_list = extensions.split(';')
+            # Add "" (no extension) as a possibility.
+            extensions_list.insert(0, "")
+            for ext in extensions_list:
+                extended_path = path + ext
+                if os.path.isfile(extended_path) and os.access(extended_path, os.X_OK):
+                    return True
+        return False
 
     @staticmethod
     def command_exists(command):
         """Return whether a particular command is available on $PATH"""
-
-        if sys.platform == 'win32':
-            # Tack .exe on if the command doesn't have an extension
-            _, extension = os.path.splitext(command)
-            if not extension:
-                command += '.exe'
 
         fpath, fname = os.path.split(command)
 
@@ -89,7 +102,7 @@ class ToolPlugin(IPlugin):
         else:
             for path in os.environ["PATH"].split(os.pathsep):
                 exe_path = os.path.join(path, command)
-                if os.path.isfile(exe_path) and os.access(exe_path, os.X_OK):
+                if ToolPlugin.is_valid_executable(exe_path):
                     return True
 
         return False

--- a/tests/tool_plugin/test_tool_plugin.py
+++ b/tests/tool_plugin/test_tool_plugin.py
@@ -99,11 +99,11 @@ def test_tool_plugin_is_valid_executable_valid():
     """Test that is_valid_executable returns True for executable files."""
 
     # Create an executable file
-    _, filename = tempfile.mkstemp()
-    st = os.stat(filename)
-    os.chmod(filename, st.st_mode | stat.S_IXUSR)
+    tmp_file = tempfile.NamedTemporaryFile()
+    st = os.stat(tmp_file.name)
+    os.chmod(tmp_file.name, st.st_mode | stat.S_IXUSR)
 
-    assert ToolPlugin.is_valid_executable(filename)
+    assert ToolPlugin.is_valid_executable(tmp_file.name)
 
 
 def test_tool_plugin_is_valid_executable_no_exe_flag():
@@ -118,8 +118,8 @@ def test_tool_plugin_is_valid_executable_no_exe_flag():
     if sys.platform.startswith('win32'):
         pytest.skip("windows doesn't have executable flags")
     # Create a file
-    _, filename = tempfile.mkstemp()
-    assert not ToolPlugin.is_valid_executable(filename)
+    tmp_file = tempfile.NamedTemporaryFile()
+    assert not ToolPlugin.is_valid_executable(tmp_file.name)
 
 
 def test_tool_plugin_is_valid_executable_nonexistent():

--- a/tests/tool_plugin/test_tool_plugin.py
+++ b/tests/tool_plugin/test_tool_plugin.py
@@ -2,7 +2,10 @@
 import argparse
 import os
 import stat
+import sys
 import tempfile
+
+import pytest
 
 from statick_tool.config import Config
 from statick_tool.plugin_context import PluginContext
@@ -104,7 +107,16 @@ def test_tool_plugin_is_valid_executable_valid():
 
 
 def test_tool_plugin_is_valid_executable_no_exe_flag():
-    """Test that is_valid_executable returns False for a non-executable file."""
+    """
+    Test that is_valid_executable returns False for a non-executable file.
+
+    NOTE: any platform which doesn't have executable bits should skip
+    this test, since the os.stat call will always say that the file is
+    executable
+    """
+
+    if sys.platform.startswith('win32'):
+        pytest.skip("windows doesn't have executable flags")
     # Create a file
     _, filename = tempfile.mkstemp()
     assert not ToolPlugin.is_valid_executable(filename)

--- a/tests/tool_plugin/test_tool_plugin.py
+++ b/tests/tool_plugin/test_tool_plugin.py
@@ -1,6 +1,8 @@
 """Tests for statick_tool.tool_plugin."""
 import argparse
 import os
+import stat
+import tempfile
 
 from statick_tool.config import Config
 from statick_tool.plugin_context import PluginContext
@@ -88,3 +90,26 @@ def test_tool_plugin_get_user_flags_valid_flags():
     tp.set_plugin_context(plugin_context)
     flags = tp.get_user_flags('level', name='test')
     assert flags == ['look', 'a', 'flag']
+
+
+def test_tool_plugin_is_valid_executable_valid():
+    """Test that is_valid_executable returns True for executable files."""
+
+    # Create an executable file
+    _, filename = tempfile.mkstemp()
+    st = os.stat(filename)
+    os.chmod(filename, st.st_mode | stat.S_IXUSR)
+
+    assert ToolPlugin.is_valid_executable(filename)
+
+
+def test_tool_plugin_is_valid_executable_no_exe_flag():
+    """Test that is_valid_executable returns False for a non-executable file."""
+    # Create a file
+    _, filename = tempfile.mkstemp()
+    assert not ToolPlugin.is_valid_executable(filename)
+
+
+def test_tool_plugin_is_valid_executable_nonexistent():
+    """Test that is_valid_executable returns False for a nonexistent file."""
+    assert not ToolPlugin.is_valid_executable('nonexistent')

--- a/tests/tool_plugin/test_tool_plugin.py
+++ b/tests/tool_plugin/test_tool_plugin.py
@@ -237,7 +237,7 @@ def test_tool_plugin_command_exists_fullpath(monkeypatch):
     assert ToolPlugin.command_exists(tmp_file.name)
 
     # Cleanup
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def test_tool_plugin_command_exists_shortpath_valid(monkeypatch):
@@ -261,7 +261,7 @@ def test_tool_plugin_command_exists_shortpath_valid(monkeypatch):
     assert ToolPlugin.command_exists(tmp_file_name)
 
     # Cleanup
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def test_tool_plugin_command_exists_shortpath_invalid(monkeypatch):
@@ -283,4 +283,4 @@ def test_tool_plugin_command_exists_shortpath_invalid(monkeypatch):
     assert not ToolPlugin.command_exists(tmp_file_name)
 
     # Cleanup
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
This MR adds a couple of static functions to tool_plugin to check whether some arbitrary command exists on the command line, plus a bunch of tests to make sure I got the corner cases right on both Windows-like and Linux-like environments. The idea for this function is to be a sanity check for tool plugins - they can check if commands they depend on (so cmake, or xmllint, or something like that) exists, and exit early if not, rather than failing when we call subprocess.