### PR TITLE
Regression fix: Add missing reporting plugins to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=['statick_tool'],
     package_data={'statick_tool': ['rsc/*', 'rsc/.clang-format', 'rsc/plugin_mapping/*',
                                    'plugins/*.py', 'plugins/discovery/*',
-                                   'plugins/tool/*']},
+                                   'plugins/tool/*', 'plugins/reporting/*']},
     scripts=['statick', 'statick_ws', 'statick_gauntlet'],
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Minor whoopsie on my part - the reporting plugins weren't added to setup.py, so they're not getting installed (and so Statick isn't giving any output). This MR fixes that. Would appreciate a patch release after this is merged since this is a regression.