### PR TITLE
Switching use of iteritems to use Python 2/3 compatability module six.

### DIFF
--- a/statick_tool/plugins/reporting/print_to_console_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/print_to_console_reporting_plugin.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 
 from collections import OrderedDict
 
+from six import iteritems
+
 from statick_tool.reporting_plugin import ReportingPlugin
 
 
@@ -25,7 +27,7 @@ class PrintToConsoleReportingPlugin(ReportingPlugin):
             level: (:obj:`str`): Name of the level used in the scan
         """
         total = 0
-        for key, value in issues.iteritems():
+        for key, value in iteritems(issues):
             unique_issues = list(OrderedDict.fromkeys(value))
             print("Tool {}: {} unique issues".format(key, len(unique_issues)))
             for issue in unique_issues:

--- a/statick_tool/plugins/reporting/write_file_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/write_file_reporting_plugin.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 
 import os
 
+from six import iteritems
+
 from statick_tool.reporting_plugin import ReportingPlugin
 
 
@@ -39,7 +41,7 @@ class WriteFileReportingPlugin(ReportingPlugin):
                                    package.name + "-" + level + ".statick")
         print("Writing output to {}".format(output_file))
         with open(output_file, "w") as out:
-            for _, value in issues.iteritems():
+            for _, value in iteritems(issues):
                 for issue in value:
                     if issue.cert_reference:
                         line = "[%s][%s][%s:%s][%s (%s)][%s]\n" % (issue.filename,


### PR DESCRIPTION
Adding additional result string to skip for CCCC tool plugin. The string indicates a result that is not applicable.