### PR TITLE
Fix PyCodeStyle and PyDocStyle handling of user flags

### DIFF
--- a/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
@@ -25,9 +25,9 @@ class PycodestyleToolPlugin(ToolPlugin):
         # https://github.com/PyCQA/pycodestyle/issues/466
         # We want to support the old tool name in configuration files for a
         # while.
-        if user_flags is None:
+        if not user_flags:
             user_flags = self.get_user_flags(level, "pep8")
-            if user_flags is not None:
+            if user_flags:
                 print("DEPRECATION WARNING: The tool name changed from pep8 to "
                       "pycodestyle. Please update your configuration file to "
                       "use the new tool name.")

--- a/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
@@ -25,9 +25,9 @@ class PydocstyleToolPlugin(ToolPlugin):
         # https://github.com/PyCQA/pydocstyle/issues/172
         # We want to support the old tool name in configuration files for a
         # while.
-        if user_flags is None:
+        if not user_flags:
             user_flags = self.get_user_flags(level, "pep257")
-            if user_flags is not None:
+            if user_flags:
                 print("DEPRECATION WARNING: The tool name changed from pep257 to "
                       "pydocstyle. Please update your configuration file to "
                       "use the new tool name.")


### PR DESCRIPTION
user_flags will never return None, it will return [] in the default case. Switch the pycodestyle/pydocstyle flag logic to accomodate that.