### PR TITLE
Safely handle nonexistent profile files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## Unreleased
+### Added:
+  - Started keeping a Changelog
+
+### Fixed:
+  - Fix backtrace when Statick is run with a nonexistent file as a profile

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -98,8 +98,10 @@ class Statick(object):
             return None
         try:
             profile = Profile(profile_resource)
-        except IOError:
-            print("Could not find profile file {}!".format(profile_filename))
+        except IOError as ex:
+            # This isn't quite redundant with the profile_resource check: it's possible
+            # that something else triggers an IOError, like permissions
+            print("Failed to access profile file {}: {}".format(profile_filename, ex))
             return None
         except ValueError as ex:
             print("Profile file {} has errors: {}".format(profile_filename, ex))

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -92,8 +92,12 @@ class Statick(object):
         profile_filename = "profile.yaml"
         if args.profile is not None:
             profile_filename = args.profile
+        profile_resource = self.resources.get_file(profile_filename)
+        if profile_resource is None:
+            print("Could not find profile file {}!".format(profile_filename))
+            return None
         try:
-            profile = Profile(self.resources.get_file(profile_filename))
+            profile = Profile(profile_resource)
         except IOError:
             print("Could not find profile file {}!".format(profile_filename))
             return None

--- a/tests/statick/rsc/profile-test.yaml
+++ b/tests/statick/rsc/profile-test.yaml
@@ -1,0 +1,4 @@
+default: "default_value"
+
+packages:
+  package: "package_specific"

--- a/tests/statick/test_statick.py
+++ b/tests/statick/test_statick.py
@@ -1,0 +1,81 @@
+"""Unit tests of statick.py."""
+
+import os
+
+import mock
+import pytest
+
+from statick_tool.args import Args
+from statick_tool.statick import Statick
+
+
+@pytest.fixture
+def init_statick():
+    """Fixture to initialize a Statick instance."""
+    args = Args("Statick tool")
+
+    return Statick(args.get_user_paths(["--user-paths",
+                                        os.path.dirname(__file__)]))
+
+
+# The Profile module has more in-depth test cases, this test module is just
+# concerned with the possible returns from the constructor.
+def test_get_level(init_statick):
+    """
+    Test searching for a level which has a corresponding file.
+
+    Expected result: Some level is returned
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--profile", dest="profile",
+                             type=str, default="profile-test.yaml")
+    level = init_statick.get_level("some_package", args.get_args([]))
+    assert level == "default_value"
+
+
+def test_get_level_non_default(init_statick):
+    """
+    Test searching for a level when a package has a custom level.
+
+    Expected result: Some level is returned
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--profile", dest="profile",
+                             type=str, default="profile-test.yaml")
+    level = init_statick.get_level("package", args.get_args([]))
+    assert level == "package_specific"
+
+
+def test_get_level_nonexistent_file(init_statick):
+    """
+    Test searching for a level which doesn't have a corresponding file.
+
+    Expected result: None is returned
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--profile", dest="profile",
+                             type=str, default="nonexistent.yaml")
+    level = init_statick.get_level("some_package", args.get_args([]))
+    assert level is None
+
+
+@mock.patch('statick_tool.statick.Profile')
+def test_get_level_ioerror(mocked_profile_constructor, init_statick):
+    """Test the behavior when Profile throws an IOError."""
+    mocked_profile_constructor.side_effect = IOError("error")
+    args = Args("Statick tool")
+    args.parser.add_argument("--profile", dest="profile",
+                             type=str, default="profile-test.yaml")
+    level = init_statick.get_level("some_package", args.get_args([]))
+    assert level is None
+
+
+@mock.patch('statick_tool.statick.Profile')
+def test_get_level_valueerror(mocked_profile_constructor, init_statick):
+    """Test the behavior when Profile throws a ValueError."""
+    mocked_profile_constructor.side_effect = ValueError("error")
+    args = Args("Statick tool")
+    args.parser.add_argument("--profile", dest="profile",
+                             type=str, default="profile-test.yaml")
+    level = init_statick.get_level("some_package", args.get_args([]))
+    assert level is None


### PR DESCRIPTION
As mentioned in #104, a backtrace is triggered if an invalid profile is passed to Statick (because `self.resources.get_file` returns `None` but the value isn't checked). This commit fixes that and adds tests for `statick_tool.statick.get_level` to verify the fix.

Special bonus feature: This commit adds a changelog!