### PR TITLE
Removing support for deprecated pep8 and pep257 tools. They work the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed:
 
+### Removed:
+  - Removed support for previously deprecated pep8 and pep257 tools.
+    The pycodestyle and pydocstyle tools provide the same functionality, only the tool name needs to change in the configuration file.
+
 ## v0.2.13 - 2019-09-22
 ### Added:
   - Python 3.8-dev is now part of the test matrix for Travis jobs.

--- a/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
@@ -20,17 +20,6 @@ class PycodestyleToolPlugin(ToolPlugin):
         """Run tool and gather output."""
         flags = ["--format=pylint"]
         user_flags = self.get_user_flags(level)
-        # This check is done to support the switch from the pep8 package name
-        # to the pycodestyle package name. See:
-        # https://github.com/PyCQA/pycodestyle/issues/466
-        # We want to support the old tool name in configuration files for a
-        # while.
-        if not user_flags:
-            user_flags = self.get_user_flags(level, "pep8")
-            if user_flags:
-                print("DEPRECATION WARNING: The tool name changed from pep8 to "
-                      "pycodestyle. Please update your configuration file to "
-                      "use the new tool name.")
         flags += user_flags
 
         total_output = []

--- a/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
@@ -20,17 +20,6 @@ class PydocstyleToolPlugin(ToolPlugin):
         """Run tool and gather output."""
         flags = []
         user_flags = self.get_user_flags(level)
-        # This check is done to support the switch from the pep257 package name
-        # to the pydocstyle package name. See:
-        # https://github.com/PyCQA/pydocstyle/issues/172
-        # We want to support the old tool name in configuration files for a
-        # while.
-        if not user_flags:
-            user_flags = self.get_user_flags(level, "pep257")
-            if user_flags:
-                print("DEPRECATION WARNING: The tool name changed from pep257 to "
-                      "pydocstyle. Please update your configuration file to "
-                      "use the new tool name.")
         flags += user_flags
         total_output = []
 

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -206,21 +206,8 @@ class Statick(object):
             plugin_name = plugins_to_run[0]
 
             if plugin_name not in self.tool_plugins:
-                if plugin_name == "pep257":
-                    plugin_name = "pydocstyle"
-                    plugins_to_run.remove("pep257")
-                    plugins_to_run.insert(0, plugin_name)
-                    print("DEPRECATION WARNING: The pep257 tool has been renamed "
-                          "as the pydocstyle tool. Please update your configuration.")
-                elif plugin_name == "pep8":
-                    plugin_name = "pycodestyle"
-                    plugins_to_run.remove("pep8")
-                    plugins_to_run.insert(0, plugin_name)
-                    print("DEPRECATION WARNING: The pep8 tool has been renamed "
-                          "as the pycodestyle tool. Please update your configuration.")
-                else:
-                    print("Can't find specified tool plugin {}!".format(plugin_name))
-                    return None, False
+                print("Can't find specified tool plugin {}!".format(plugin_name))
+                return None, False
 
             if args.force_tool_list is not None:
                 force_tool_list = args.force_tool_list.split(",")


### PR DESCRIPTION
…same, but must be called out in the configuration as pycodestyle and pydocstyle.