### PR TITLE
Fix bug in setup.py installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description='Making code quality easier and tailored for you.',
     version=statick_tool.__version__,
     packages=['statick_tool'],
-    package_data={'statick_tool': ['rsc/*', 'rsc/.clang-format',
+    package_data={'statick_tool': ['rsc/*.*', 'rsc/.clang-format',
                                    'rsc/plugin_mapping/*',
                                    'plugins/*.py', 'plugins/discovery/*',
                                    'plugins/tool/*', 'plugins/reporting/*']},


### PR DESCRIPTION
Use pattern 'rsc/*.*' to prevent picking up the plugin_mapping directory.