### PR TITLE
Small changes to the installation instructions based on my experience…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The exact package names may vary for other systems.
 These packages are for the tools used by the default configuration of Statick.
 Depending on your usage and configuration, you may not need these packages.
 
-    $ cat install.txt  | xargs sudo apt-get install
+    $ cat install.txt  | xargs sudo apt-get install -y
     $ pip install -r requirements.txt
 
 To run against ROS packages there are a few more system packages to get.

--- a/install.txt
+++ b/install.txt
@@ -4,6 +4,7 @@ clang-format-3.9
 clang-tidy-3.9
 libomp-dev
 libperl-critic-perl
+libpcre3-dev
 libxml2
 libxml2-utils
 uncrustify


### PR DESCRIPTION
… with Mint 19.

For me, libprce3 was needed for building cppcheck on Mint 19.

Also the installation requirements didn't automatically install as given (though maybe it's useful to preview what happens before actually installing). 