### PR TITLE
Clang format compare bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ script:
   - pip install tox
   # Borrowed from flask-mongoengine
   - tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d . | sed -e 's/pypypy/pypy/' | sed -e 's/-dev//')
+  # Forces unit tests to take non-standard paths through code.
+  - cp tests/plugins/tool/clang-format_tool_plugin/different-clang-format.cfg ~/.clang-format
 
 
 jobs:

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import difflib
+import os
 import re
 import subprocess
 
@@ -60,18 +61,17 @@ class ClangFormatToolPlugin(ToolPlugin):
         total_output = []
 
         try:
-            output = subprocess.check_output([clang_format_bin,
-                                              "--dump-config"],
-                                             stderr=subprocess.STDOUT,
-                                             universal_newlines=True)
-            format_file_name = self.plugin_context.resources.get_file("_clang-format")
-            with open(format_file_name, "r") as format_file:
+            default_file_name = "_clang-format"
+            format_file_name = self.plugin_context.resources.get_file(default_file_name)
+            with open(os.path.expanduser("~/" + default_file_name), "r") as home_format_file, \
+                    open(format_file_name, "r") as format_file:
+                actual_format = home_format_file.read()
                 target_format = format_file.read()
-            diff = difflib.context_diff(output.splitlines(),
+            diff = difflib.context_diff(actual_format.splitlines(),
                                         target_format.splitlines())
             for line in diff:
-                if line.startswith("+ ") or line.startswith("- ") or \
-                   line.startswith("! "):
+                if (line.startswith("+ ") or line.startswith("- ") or
+                   line.startswith("! ")) and len(line) > 2:
                     if line[2:].strip() and line[2:].strip()[0] != "#":
                         # pylint: disable=line-too-long
                         exc = subprocess.CalledProcessError(-1,
@@ -91,6 +91,11 @@ class ClangFormatToolPlugin(ToolPlugin):
                 if self.plugin_context.args.clang_format_raise_exception:
                     total_output.append(output)
 
+        except IOError as ex:
+            print("clang-format failed! Error = {}".format(str(ex.strerror)))
+            if self.plugin_context.args.clang_format_raise_exception:
+                return None
+            return []
         except subprocess.CalledProcessError as ex:
             output = ex.output
             print("clang-format failed! Returncode = {}".format(str(ex.returncode)))

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -71,7 +71,7 @@ class ClangFormatToolPlugin(ToolPlugin):
                                         target_format.splitlines())
             for line in diff:
                 if (line.startswith("+ ") or line.startswith("- ") or
-                   line.startswith("! ")) and len(line) > 2:
+                        line.startswith("! ")) and len(line) > 2:
                     if line[2:].strip() and line[2:].strip()[0] != "#":
                         # pylint: disable=line-too-long
                         exc = subprocess.CalledProcessError(-1,

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -76,7 +76,7 @@ class ClangFormatToolPlugin(ToolPlugin):
                         # pylint: disable=line-too-long
                         exc = subprocess.CalledProcessError(-1,
                                                             clang_format_bin,
-                                                            ".clang-format style is not correct. There is one located in {}. Put this file in your home directory.".
+                                                            "_clang-format style is not correct. There is one located in {}. Put this file in your home directory.".
                                                             format(format_file_name))
                         # pylint: enable=line-too-long
                         if self.plugin_context.args.clang_format_raise_exception:
@@ -91,11 +91,12 @@ class ClangFormatToolPlugin(ToolPlugin):
                 if self.plugin_context.args.clang_format_raise_exception:
                     total_output.append(output)
 
-        except IOError as ex:
+        except OSError as ex:
             print("clang-format failed! Error = {}".format(str(ex.strerror)))
             if self.plugin_context.args.clang_format_raise_exception:
                 return None
             return []
+
         except subprocess.CalledProcessError as ex:
             output = ex.output
             print("clang-format failed! Returncode = {}".format(str(ex.returncode)))
@@ -103,10 +104,6 @@ class ClangFormatToolPlugin(ToolPlugin):
             if self.plugin_context.args.clang_format_raise_exception:
                 return None
             return []
-
-        except OSError as ex:
-            print("Couldn't find {}! ({})".format(clang_format_bin, ex))
-            return None
 
         if self.plugin_context.args.show_tool_output:
             for output in total_output:

--- a/tests/plugins/tool/clang-format_tool_plugin/different-clang-format.cfg
+++ b/tests/plugins/tool/clang-format_tool_plugin/different-clang-format.cfg
@@ -1,0 +1,4 @@
+---
+Language:        Cpp
+UseTab:          Never
+...

--- a/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
+++ b/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
@@ -76,22 +76,22 @@ def test_clang_format_tool_plugin_found():
 
 # Has issues with not finding the clang-format config correctly on Travis CI.
 # Plugin probably could use some touching up in this department.
-# def test_clang_format_tool_plugin_scan_valid():
-#     """Integration test: Make sure the clang_format output hasn't changed."""
-#     cftp = setup_clang_format_tool_plugin()
-#     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
-#                                                     'valid_package'))
-#     # Copy the latest clang_format over
-#     shutil.copyfile(cftp.plugin_context.resources.get_file("_clang-format"),
-#                     os.path.join(os.path.expanduser("~"), '.clang-format'))
-#     package['make_targets'] = []
-#     package['make_targets'].append({})
-#     package['make_targets'][0]['src'] = [os.path.join(os.path.dirname(__file__),
-#                                                       'valid_package', 'indents.c')]
-#     package['headers'] = [os.path.join(os.path.dirname(__file__),
-#                                        'valid_package', 'indents.h')]
-#     issues = cftp.scan(package, 'level')
-#     assert len(issues) == 1
+def test_clang_format_tool_plugin_scan_valid():
+    """Integration test: Make sure the clang_format output hasn't changed."""
+    cftp = setup_clang_format_tool_plugin()
+    package = Package('valid_package', os.path.join(os.path.dirname(__file__),
+                                                    'valid_package'))
+    # Copy the latest clang_format over
+    shutil.copyfile(cftp.plugin_context.resources.get_file("_clang-format"),
+                    os.path.join(os.path.expanduser("~"), '_clang-format'))
+    package['make_targets'] = []
+    package['make_targets'].append({})
+    package['make_targets'][0]['src'] = [os.path.join(os.path.dirname(__file__),
+                                                      'valid_package', 'indents.c')]
+    package['headers'] = [os.path.join(os.path.dirname(__file__),
+                                       'valid_package', 'indents.h')]
+    issues = cftp.scan(package, 'level')
+    assert len(issues) == 1
 
 
 def test_clang_format_tool_plugin_scan_missing_fields():
@@ -107,7 +107,7 @@ def test_clang_format_tool_plugin_scan_missing_fields():
 def test_clang_format_tool_plugin_scan_missing_config_file():
     """Test that issues are None when configuration file is different."""
     cftp = setup_clang_format_tool_plugin()
-    with open(os.path.join(os.path.expanduser("~"), '.clang-format'), 'a') as fin:
+    with open(os.path.join(os.path.expanduser("~"), '_clang-format'), 'a') as fin:
         fin.write('invalid entry')
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
@@ -124,7 +124,7 @@ def test_clang_format_tool_plugin_scan_missing_config_file():
 def test_clang_format_tool_plugin_scan_missing_config_file_non_default():
     """Test that issues is empty when configuration file is different."""
     cftp = setup_clang_format_tool_plugin_non_default()
-    with open(os.path.join(os.path.expanduser("~"), '.clang-format'), 'a') as fin:
+    with open(os.path.join(os.path.expanduser("~"), '_clang-format'), 'a') as fin:
         fin.write('invalid entry')
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
@@ -164,36 +164,13 @@ def test_clang_format_tool_plugin_parse_invalid():
     assert not issues
 
 
-@mock.patch('statick_tool.plugins.tool.clang_format_tool_plugin.subprocess.check_output')
-def test_clang_format_tool_plugin_scan_ioerror(mock_subprocess_check_output):
-    """
-    Test what happens when a CalledProcessError is raised (usually means clang-format hit an error).
-
-    Expected result: issues is empty
-    """
-    mock_subprocess_check_output.side_effect = IOError("~/_clang-format")
+def test_clang_format_tool_plugin_custom_config_diff():
+    """Verify that we can identify a diff between actual and target formats."""
     cftp = setup_clang_format_tool_plugin()
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
-    package['make_targets'] = []
-    package['headers'] = []
-    issues = cftp.scan(package, 'level')
-    assert not issues
-
-
-@mock.patch('statick_tool.plugins.tool.clang_format_tool_plugin.subprocess.check_output')
-def test_clang_format_tool_plugin_scan_ioerror_non_default(mock_subprocess_check_output):
-    """
-    Test what happens when a CalledProcessError is raised (usually means clang-format hit an error).
-
-    Expected result: issues is empty
-    """
-    mock_subprocess_check_output.side_effect = IOError("~/_clang-format")
-    cftp = setup_clang_format_tool_plugin_non_default()
-    package = Package('valid_package', os.path.join(os.path.dirname(__file__),
-                                                    'valid_package'))
-    package['make_targets'] = []
-    package['headers'] = []
+    cftp.plugin_context.resources
+    # Issues should be empty until make_targets is added to the package.
     issues = cftp.scan(package, 'level')
     assert not issues
 
@@ -208,7 +185,7 @@ def test_clang_format_tool_plugin_scan_calledprocesserror(mock_subprocess_check_
     mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(1, '', output="mocked error")
     cftp = setup_clang_format_tool_plugin()
     shutil.copyfile(cftp.plugin_context.resources.get_file("_clang-format"),
-                    os.path.join(os.path.expanduser("~"), '.clang-format'))
+                    os.path.join(os.path.expanduser("~"), '_clang-format'))
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
     package['make_targets'] = []
@@ -227,7 +204,7 @@ def test_clang_format_tool_plugin_scan_calledprocesserror_non_default(mock_subpr
     mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(1, '', output="mocked error")
     cftp = setup_clang_format_tool_plugin_non_default()
     shutil.copyfile(cftp.plugin_context.resources.get_file("_clang-format"),
-                    os.path.join(os.path.expanduser("~"), '.clang-format'))
+                    os.path.join(os.path.expanduser("~"), '_clang-format'))
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
     package['make_targets'] = []
@@ -246,7 +223,7 @@ def test_clang_format_tool_plugin_scan_oserror(mock_subprocess_check_output):
     mock_subprocess_check_output.side_effect = OSError('mocked error')
     cftp = setup_clang_format_tool_plugin()
     shutil.copyfile(cftp.plugin_context.resources.get_file("_clang-format"),
-                    os.path.join(os.path.expanduser("~"), '.clang-format'))
+                    os.path.join(os.path.expanduser("~"), '_clang-format'))
     package = Package('valid_package', os.path.join(os.path.dirname(__file__),
                                                     'valid_package'))
     package['make_targets'] = []

--- a/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
+++ b/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
@@ -165,6 +165,40 @@ def test_clang_format_tool_plugin_parse_invalid():
 
 
 @mock.patch('statick_tool.plugins.tool.clang_format_tool_plugin.subprocess.check_output')
+def test_clang_format_tool_plugin_scan_ioerror(mock_subprocess_check_output):
+    """
+    Test what happens when a CalledProcessError is raised (usually means clang-format hit an error).
+
+    Expected result: issues is empty
+    """
+    mock_subprocess_check_output.side_effect = IOError("~/_clang-format")
+    cftp = setup_clang_format_tool_plugin()
+    package = Package('valid_package', os.path.join(os.path.dirname(__file__),
+                                                    'valid_package'))
+    package['make_targets'] = []
+    package['headers'] = []
+    issues = cftp.scan(package, 'level')
+    assert not issues
+
+
+@mock.patch('statick_tool.plugins.tool.clang_format_tool_plugin.subprocess.check_output')
+def test_clang_format_tool_plugin_scan_ioerror_non_default(mock_subprocess_check_output):
+    """
+    Test what happens when a CalledProcessError is raised (usually means clang-format hit an error).
+
+    Expected result: issues is empty
+    """
+    mock_subprocess_check_output.side_effect = IOError("~/_clang-format")
+    cftp = setup_clang_format_tool_plugin_non_default()
+    package = Package('valid_package', os.path.join(os.path.dirname(__file__),
+                                                    'valid_package'))
+    package['make_targets'] = []
+    package['headers'] = []
+    issues = cftp.scan(package, 'level')
+    assert not issues
+
+
+@mock.patch('statick_tool.plugins.tool.clang_format_tool_plugin.subprocess.check_output')
 def test_clang_format_tool_plugin_scan_calledprocesserror(mock_subprocess_check_output):
     """
     Test what happens when a CalledProcessError is raised (usually means clang-format hit an error).

--- a/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
+++ b/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
@@ -75,8 +75,6 @@ def test_clang_format_tool_plugin_found():
                plugin_info in manager.getPluginsOfCategory("Tool"))
 
 
-# Has issues with not finding the clang-format config correctly on Travis CI.
-# Plugin probably could use some touching up in this department.
 def test_clang_format_tool_plugin_scan_valid():
     """Integration test: Make sure the clang_format output hasn't changed."""
     cftp = setup_clang_format_tool_plugin()


### PR DESCRIPTION
Updating clang-format plugin to compare plugin's context clang format file directly to the one in the user's home dir instead of clang-format --dump-config. This is because the dump-config option doesn't handle multiple languages in the .clang-format file, it only outputs one language's configuration at a time.