### PR TITLE
Replacing all usages of IOError with OSError. IOError was merged into…

### DIFF
--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -114,9 +114,9 @@ class Statick(object):
             return None
         try:
             profile = Profile(profile_resource)
-        except IOError as ex:
+        except OSError as ex:
             # This isn't quite redundant with the profile_resource check: it's possible
-            # that something else triggers an IOError, like permissions
+            # that something else triggers an OSError, like permissions
             print("Failed to access profile file {}: {}".format(profile_filename, ex))
             return None
         except ValueError as ex:

--- a/statick_ws
+++ b/statick_ws
@@ -54,7 +54,7 @@ def main():  # pylint: disable=too-many-locals, too-many-branches, too-many-stat
                                       in fname.readlines()
                                       if package.strip() and
                                       package[0] != "#"]
-        except IOError:
+        except OSError:
             print("Packages file not found")
             sys.exit(1)
         packages = [package for package in packages if package[0] in packages_file_list]

--- a/tests/exceptions/test_exceptions.py
+++ b/tests/exceptions/test_exceptions.py
@@ -21,11 +21,11 @@ def test_exceptions_init_valid():
 
 def test_exceptions_init_nonexistent():
     """
-    Test that the Exceptions module throws an IOError if a bad path is given.
+    Test that the Exceptions module throws an OSError if a bad path is given.
 
-    Expected result: IOError thrown.
+    Expected result: OSError thrown.
     """
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         Exceptions(os.path.join(os.path.dirname(__file__),
                                 'nonexistent_exceptions.yaml'))
 

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -21,9 +21,9 @@ def test_profile_nonexistent():
     """
     Test for when a Profile is initialized with a nonexistent YAML.
 
-    Expected result: IOError is thrown
+    Expected result: OSError is thrown
     """
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         Profile(os.path.join(os.path.dirname(__file__), 'nope.yaml'))
 
 

--- a/tests/statick/test_statick.py
+++ b/tests/statick/test_statick.py
@@ -82,8 +82,8 @@ def test_get_level_nonexistent_file(init_statick):
 
 @mock.patch('statick_tool.statick.Profile')
 def test_get_level_ioerror(mocked_profile_constructor, init_statick):
-    """Test the behavior when Profile throws an IOError."""
-    mocked_profile_constructor.side_effect = IOError("error")
+    """Test the behavior when Profile throws an OSError."""
+    mocked_profile_constructor.side_effect = OSError("error")
     args = Args("Statick tool")
     args.parser.add_argument("--profile", dest="profile",
                              type=str, default="profile-test.yaml")


### PR DESCRIPTION
… OSError in Python 3.3.