### PR TITLE
Setting make tool plugin to return None when a subprocess check_outpu…

### DIFF
--- a/statick_tool/plugins/tool/make_tool_plugin.py
+++ b/statick_tool/plugins/tool/make_tool_plugin.py
@@ -21,9 +21,8 @@ class MakeToolPlugin(ToolPlugin):
         if "make_targets" not in package:
             return []
 
-        extra_args = []
         output = None
-        make_args = ["make", "statick_cmake_target"] + extra_args
+        make_args = ["make", "statick_cmake_target"]
 
         try:
             output = subprocess.check_output(["make", "clean"],
@@ -33,10 +32,12 @@ class MakeToolPlugin(ToolPlugin):
                                              universal_newlines=True)
             if self.plugin_context.args.show_tool_output:
                 print("{}".format(output))
+
         except subprocess.CalledProcessError as ex:
             output = ex.output
             print("Make failed! Returncode = {}".format(ex.returncode))
-            print("{}".format(ex.output))
+            print("Exception output: {}".format(ex.output))
+            return None
 
         except OSError as ex:
             print("Couldn't find make executable! ({})".format(ex))

--- a/tests/plugins/tool/make_tool_plugin/test_make_tool_plugin.py
+++ b/tests/plugins/tool/make_tool_plugin/test_make_tool_plugin.py
@@ -52,6 +52,18 @@ def test_make_tool_plugin_found():
                plugin_info in manager.getPluginsOfCategory("Tool"))
 
 
+def test_make_tool_plugin_scan_valid():
+    """Integration test: Make sure the make output hasn't changed."""
+    mtp = setup_make_tool_plugin()
+    if not mtp.command_exists('make'):
+        pytest.skip('Missing make executable.')
+    package = Package('valid_package', os.path.join(os.path.dirname(__file__),
+                                                    'valid_package'))
+    package['make_targets'] = 'make_targets'
+    issues = mtp.scan(package, 'level')
+    assert not issues
+
+
 def test_make_tool_plugin_scan_missing_tool_name():
     """Check that a missing tool name results in an empty list of issues."""
     mtp = setup_make_tool_plugin()


### PR DESCRIPTION
…t command fails. This will cause Statick to exit with an error condition. A new unit test was added to check for valid make scans.