### PR TITLE
Opening issue file with utf-8 encoding.

### DIFF
--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -154,7 +154,7 @@ class Exceptions(object):
                         self.print_exception_warning(tool)
                         warning_printed = True
                     continue
-                lines = open(issue.filename, "r").readlines()
+                lines = open(issue.filename, "r+", encoding="utf-8").readlines()
                 line_number = int(issue.line_number) - 1
                 if line_number < len(lines) and "NOLINT" in lines[line_number]:
                     to_remove.append(issue)


### PR DESCRIPTION
There have been cases where opening the issue file results
in a UnicodeDecodeError exception. This is an attempt
to fix that. Credit to:

https://stackoverflow.com/questions/18649512/unicodedecodeerror-ascii-codec-cant-decode-byte-0xe2-in-position-13-ordinal