### PR TITLE
Fixed bug that can occur when certain types of regular expressions are used for exceptions.

### DIFF
--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -139,7 +139,13 @@ class Exceptions:
         for exception in exceptions:
             exception_re = exception["regex"]
             exception_tools = exception["tools"]
-            compiled_re = re.compile(exception_re)  # type: Pattern
+            try:
+                compiled_re = re.compile(exception_re)  # type: Pattern
+            except re.error:
+                print(
+                    "Invalid regular expression in exception: {}".format(exception_re)
+                )
+                continue
             for tool, tool_issues in list(issues.items()):
                 to_remove = []
                 if exception_tools == "all" or tool in exception_tools:

--- a/tests/exceptions/package_exceptions.yaml
+++ b/tests/exceptions/package_exceptions.yaml
@@ -8,3 +8,5 @@ packages:
         # Python 2/3 compatibility requires inheriting from `object`.
         - tools: [pylint]
           regex: ".+: Class .+ inherits from object, can be safely removed from bases in python3"
+        - tools: [catkin_lint]
+          regex: "*some string*"

--- a/tests/exceptions/test_exceptions.py
+++ b/tests/exceptions/test_exceptions.py
@@ -112,7 +112,7 @@ def test_package_exceptions():
     """
     Test that package exceptions are found.
 
-    Expected result: no issues found
+    Expected result: exceptions are found for both file and message_regex types
     """
     package = Package(
         "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
@@ -123,7 +123,7 @@ def test_package_exceptions():
     package_exceptions = exceptions.get_exceptions(package)
 
     assert len(package_exceptions["file"]) == 1
-    assert len(package_exceptions["message_regex"]) == 1
+    assert len(package_exceptions["message_regex"]) == 2
 
 
 def test_filter_issues():
@@ -218,6 +218,33 @@ def test_filter_issues_nolint_not_abs_path():
     )
     exceptions = Exceptions(
         os.path.join(os.path.dirname(__file__), "valid_exceptions.yaml")
+    )
+
+    filename = "valid_package/x.py"
+    line_number = "3"
+    tool = "pylint"
+    issue_type = "missing-docstring"
+    severity = "3"
+    message = "C0111: Missing module docstring"
+    tool_issue = Issue(filename, line_number, tool, issue_type, severity, message, None)
+    issues = {}
+    issues["pylint"] = [tool_issue]
+
+    issues = exceptions.filter_issues(package, issues)
+    assert len(issues["pylint"]) == 1
+
+
+def test_filter_issues_wildcard_exceptions():
+    """
+    Test that issues are found even when exceptions with wildcards for regex are used.
+
+    Expected result: one issue found
+    """
+    package = Package(
+        "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
+    )
+    exceptions = Exceptions(
+        os.path.join(os.path.dirname(__file__), "package_exceptions.yaml")
     )
 
     filename = "valid_package/x.py"


### PR DESCRIPTION
The error is now caught and ignored. A unit test was added to verify these regular expressions will be handled appropriately in the future.