### PR TITLE
Add unit tests for statick module

### DIFF
--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -91,7 +91,6 @@ class Statick:
 
     def get_ignore_packages(self) -> List[str]:
         """Get packages to ignore during scan process."""
-        assert self.exceptions
         return self.exceptions.get_ignore_packages()
 
     def gather_args(self, args: argparse.Namespace) -> None:
@@ -194,8 +193,11 @@ class Statick:
 
         package = Package(os.path.basename(path), path)
         level = self.get_level(path, args)  # type: Optional[str]
+        print("level: {}".format(level))
+        if level is None:
+            print("Level is not valid.")
+            return None, False
 
-        assert level
         if not self.config or not self.config.has_level(level):
             print("Can't find specified level {} in config!".format(level))
             return None, False

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -91,6 +91,8 @@ class Statick:
 
     def get_ignore_packages(self) -> List[str]:
         """Get packages to ignore during scan process."""
+        if self.exceptions is None:
+            return []
         return self.exceptions.get_ignore_packages()
 
     def gather_args(self, args: argparse.Namespace) -> None:

--- a/tests/statick/rsc/config-enabled-dependency.yaml
+++ b/tests/statick/rsc/config-enabled-dependency.yaml
@@ -1,0 +1,7 @@
+levels:
+  sei_cert:
+    tool:
+      cppcheck:
+        flags: ""
+      make:
+        flags: ""

--- a/tests/statick/rsc/config-invalid-reporting-plugins.yaml
+++ b/tests/statick/rsc/config-invalid-reporting-plugins.yaml
@@ -1,0 +1,4 @@
+levels:
+  sei_cert:
+    reporting:
+      - not_a_plugin

--- a/tests/statick/rsc/config-missing-tool-dependency.yaml
+++ b/tests/statick/rsc/config-missing-tool-dependency.yaml
@@ -1,0 +1,4 @@
+levels:
+  sei_cert:
+    tool:
+      - cppcheck

--- a/tests/statick/rsc/config-missing-tool.yaml
+++ b/tests/statick/rsc/config-missing-tool.yaml
@@ -1,0 +1,4 @@
+levels:
+  missing_tool:
+    tool:
+      - not_a_plugin

--- a/tests/statick/rsc/config-no-reporting-plugins.yaml
+++ b/tests/statick/rsc/config-no-reporting-plugins.yaml
@@ -1,0 +1,4 @@
+levels:
+  sei_cert:
+    tool:
+      pyflakes

--- a/tests/statick/rsc/config-test.yaml
+++ b/tests/statick/rsc/config-test.yaml
@@ -1,5 +1,8 @@
 levels:
   default_value:
+    discovery:
+      - not_a_plugin
     tool:
-      not_a_tool:
-        flags: ""
+      - not_a_plugin
+    reporting:
+      - not_a_plugin

--- a/tests/statick/rsc/profile-missing-tool.yaml
+++ b/tests/statick/rsc/profile-missing-tool.yaml
@@ -1,0 +1,1 @@
+default: "missing_tool"

--- a/tests/statick/test_package/hello.py
+++ b/tests/statick/test_package/hello.py
@@ -1,0 +1,1 @@
+print("Hello world!")

--- a/tests/statick/test_statick.py
+++ b/tests/statick/test_statick.py
@@ -86,7 +86,11 @@ def test_get_level_nonexistent_file(init_statick):
 
 @mock.patch("statick_tool.statick.Profile")
 def test_get_level_ioerror(mocked_profile_constructor, init_statick):
-    """Test the behavior when Profile throws an OSError."""
+    """
+    Test the behavior when Profile throws an OSError.
+
+    Expected result: None is returned
+    """
     mocked_profile_constructor.side_effect = OSError("error")
     args = Args("Statick tool")
     args.parser.add_argument(
@@ -283,3 +287,235 @@ def test_run_force_tool_list(init_statick):
     for tool in issues:
         assert not issues[tool]
     assert success
+
+
+def test_run_package_is_ignored(init_statick):
+    """
+    Test that ignored package is ignored.
+
+    Expected results: issues is empty and success is True
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.join(os.path.dirname(__file__), "test_package"),
+        "--exceptions",
+        os.path.join(os.path.dirname(__file__), "rsc", "exceptions-test.yaml"),
+    ]
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert not issues
+    assert success
+
+
+def test_run_invalid_discovery_plugin(init_statick):
+    """
+    Test that a non-existent discovery plugin results in failure.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--profile",
+        os.path.join(os.path.dirname(__file__), "rsc", "profile-test.yaml"),
+        "--config",
+        os.path.join(os.path.dirname(__file__), "rsc", "config-test.yaml"),
+    ]
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert issues is None
+    assert not success
+
+
+def test_run_invalid_tool_plugin(init_statick):
+    """
+    Test that a non-existent tool plugin results in failure.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--profile",
+        os.path.join(os.path.dirname(__file__), "rsc", "profile-missing-tool.yaml"),
+        "--config",
+        os.path.join(os.path.dirname(__file__), "rsc", "config-missing-tool.yaml"),
+    ]
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert issues is None
+    assert not success
+
+
+def test_run_missing_tool_dependency(init_statick):
+    """
+    Test that a tool plugin results in failure when its dependency is not configured to run.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--force-tool-list",
+        "cppcheck",
+        "--config",
+        os.path.join(
+            os.path.dirname(__file__), "rsc", "config-missing-tool-dependency.yaml"
+        ),
+    ]
+    args.output_directory = os.path.dirname(__file__)
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert issues is None
+    assert not success
+
+
+def test_run_tool_dependency(init_statick):
+    """
+    Test that a tool plugin can run its dependencies.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--config",
+        os.path.join(
+            os.path.dirname(__file__), "rsc", "config-enabled-dependency.yaml"
+        ),
+        "--force-tool-list",
+        "cppcheck",
+    ]
+    args.output_directory = os.path.dirname(__file__)
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    for tool in issues:
+        assert not issues[tool]
+    assert success
+
+
+def test_run_no_reporting_plugins(init_statick):
+    """
+    Test that no reporting plugins returns unsuccessful.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--config",
+        os.path.join(
+            os.path.dirname(__file__), "rsc", "config-no-reporting-plugins.yaml"
+        ),
+    ]
+    args.output_directory = os.path.dirname(__file__)
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert issues is None
+    assert not success
+
+
+def test_run_invalid_reporting_plugins(init_statick):
+    """
+    Test that invalid reporting plugins returns unsuccessful.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--config",
+        os.path.join(
+            os.path.dirname(__file__), "rsc", "config-invalid-reporting-plugins.yaml"
+        ),
+    ]
+    args.output_directory = os.path.dirname(__file__)
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert issues is None
+    assert not success
+
+
+def test_run_invalid_level(init_statick):
+    """
+    Test that invalid profile results in invalid level.
+
+    Expected results: issues is None and success is False
+    """
+    args = Args("Statick tool")
+    args.parser.add_argument("--path", help="Path of package to scan")
+
+    statick = Statick(args.get_user_paths())
+    statick.gather_args(args.parser)
+    sys.argv = [
+        "--path",
+        os.path.dirname(__file__),
+        "--profile",
+        os.path.join(
+            os.path.dirname(__file__), "rsc", "nonexistent.yaml"
+        ),
+    ]
+    args.output_directory = os.path.dirname(__file__)
+    parsed_args = args.get_args(sys.argv)
+    path = parsed_args.path
+    statick.get_config(parsed_args)
+    statick.get_exceptions(parsed_args)
+    issues, success = statick.run(path, parsed_args)
+    assert issues is None
+    assert not success

--- a/tests/statick/test_statick.py
+++ b/tests/statick/test_statick.py
@@ -7,6 +7,7 @@ import mock
 import pytest
 
 from statick_tool.args import Args
+from statick_tool.plugins.tool.cppcheck_tool_plugin import CppcheckToolPlugin
 from statick_tool.statick import Statick
 
 
@@ -377,6 +378,9 @@ def test_run_missing_tool_dependency(init_statick):
 
     Expected results: issues is None and success is False
     """
+    cctp = CppcheckToolPlugin()
+    if not cctp.command_exists("cppcheck"):
+        pytest.skip("Can't find cppcheck, unable to test cppcheck plugin")
     args = Args("Statick tool")
     args.parser.add_argument("--path", help="Path of package to scan")
 
@@ -408,6 +412,9 @@ def test_run_tool_dependency(init_statick):
 
     Expected results: issues is None and success is False
     """
+    cctp = CppcheckToolPlugin()
+    if not cctp.command_exists("cppcheck"):
+        pytest.skip("Can't find cppcheck, unable to test cppcheck plugin")
     args = Args("Statick tool")
     args.parser.add_argument("--path", help="Path of package to scan")
 

--- a/tests/statick/test_statick.py
+++ b/tests/statick/test_statick.py
@@ -524,9 +524,7 @@ def test_run_invalid_level(init_statick):
         "--path",
         os.path.dirname(__file__),
         "--profile",
-        os.path.join(
-            os.path.dirname(__file__), "rsc", "nonexistent.yaml"
-        ),
+        os.path.join(os.path.dirname(__file__), "rsc", "nonexistent.yaml"),
     ]
     args.output_directory = os.path.dirname(__file__)
     parsed_args = args.get_args(sys.argv)

--- a/tests/statick/test_statick.py
+++ b/tests/statick/test_statick.py
@@ -116,6 +116,16 @@ def test_custom_exceptions_file(init_statick):
     assert ignore_packages == ["test_package"]
 
 
+def test_exceptions_no_file(init_statick):
+    """
+    Test finding ignored packages without specifying an exceptions file.
+
+    Expected result: ignored packages list is empty
+    """
+    ignore_packages = init_statick.get_ignore_packages()
+    assert not ignore_packages
+
+
 def test_custom_config_file(init_statick):
     """
     Test using custom config file.


### PR DESCRIPTION
* Most unit tests related to verifying behavior when plugins of various types are missing.
* Fixed bug in getting ignored packages. Edge case existed where we tried calling method on None type object. Found with mypy.