### PR TITLE
Ubuntu 20.04 fixes for CMake discovery plugin

### DIFF
--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -52,6 +52,7 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
             "cmake",
             ".",
             "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+            "-DBUILD_GMOCK=ON",
             "-DBUILD_GTEST=OFF",
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             "-DCATKIN_ENABLE_TESTING=OFF",
@@ -69,6 +70,7 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
         except subprocess.CalledProcessError as ex:
             output = ex.output
             print("Problem running CMake! Returncode = {}".format(str(ex.returncode)))
+            print("From {}, running {}".format(os.getcwd(), subproc_args))
             print("{}".format(ex.output))
 
         except OSError:

--- a/statick_tool/rsc/CMakeLists.txt.in
+++ b/statick_tool/rsc/CMakeLists.txt.in
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
+cmake_policy(SET CMP0048 NEW)
 project(statick)
 
 set(IGNORE_PROJECTS gtest)


### PR DESCRIPTION
Fixes to CMake flags and template to get CMake discovery to work on Ubuntu 20.04. This was blocking any tools that depend on CMake or Make running.