### PR TITLE
Black formatting and re-raise exceptions from original exception

### DIFF
--- a/statick_tool/config.py
+++ b/statick_tool/config.py
@@ -26,7 +26,9 @@ class Config:
             try:
                 self.config = yaml.safe_load(fname)
             except (yaml.YAMLError, yaml.scanner.ScannerError) as ex:
-                raise ValueError("{} is not a valid YAML file: {}".format(filename, ex))
+                raise ValueError(
+                    "{} is not a valid YAML file: {}".format(filename, ex)
+                ) from ex
 
     def has_level(self, level: Optional[str]) -> bool:
         """Check if given level exists in config."""

--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -33,7 +33,9 @@ class Exceptions:
             try:
                 self.exceptions = yaml.safe_load(fname)  # type: Dict[Any, Any]
             except (yaml.YAMLError, yaml.scanner.ScannerError) as ex:
-                raise ValueError("{} is not a valid YAML file: {}".format(filename, ex))
+                raise ValueError(
+                    "{} is not a valid YAML file: {}".format(filename, ex)
+                ) from ex
 
     def get_ignore_packages(self) -> List[str]:
         """Get list of packages to skip when scanning a workspace."""

--- a/statick_tool/profile.py
+++ b/statick_tool/profile.py
@@ -18,7 +18,9 @@ class Profile:  # pylint: disable=too-few-public-methods
             try:
                 self.profile = yaml.safe_load(fname)
             except yaml.YAMLError as ex:
-                raise ValueError("{} is not a valid YAML file: {}".format(filename, ex))
+                raise ValueError(
+                    "{} is not a valid YAML file: {}".format(filename, ex)
+                ) from ex
             if self.profile is None:
                 raise ValueError("{} is empty, can't continue!".format(filename))
             if "default" not in self.profile:

--- a/tests/plugins/discovery/c_discovery_plugin/test_c_discovery_plugin.py
+++ b/tests/plugins/discovery/c_discovery_plugin/test_c_discovery_plugin.py
@@ -51,7 +51,9 @@ def test_c_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "c"

--- a/tests/plugins/discovery/catkin_discovery_plugin/test_catkin_discovery_plugin.py
+++ b/tests/plugins/discovery/catkin_discovery_plugin/test_catkin_discovery_plugin.py
@@ -18,7 +18,9 @@ def test_catkin_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "catkin"

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -46,7 +46,9 @@ def test_cmake_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "cmake"

--- a/tests/plugins/discovery/java_discovery_plugin/test_java_discovery_plugin.py
+++ b/tests/plugins/discovery/java_discovery_plugin/test_java_discovery_plugin.py
@@ -19,7 +19,9 @@ def test_java_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "java"

--- a/tests/plugins/discovery/maven_discovery_plugin/test_maven_discovery_plugin.py
+++ b/tests/plugins/discovery/maven_discovery_plugin/test_maven_discovery_plugin.py
@@ -19,7 +19,9 @@ def test_maven_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "java"

--- a/tests/plugins/discovery/perl_discovery_plugin/test_perl_discovery_plugin.py
+++ b/tests/plugins/discovery/perl_discovery_plugin/test_perl_discovery_plugin.py
@@ -51,7 +51,9 @@ def test_perl_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "perl"

--- a/tests/plugins/discovery/python_discovery_plugin/test_python_discovery_plugin.py
+++ b/tests/plugins/discovery/python_discovery_plugin/test_python_discovery_plugin.py
@@ -51,7 +51,9 @@ def test_python_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "python"

--- a/tests/plugins/discovery/xml_discovery_plugin/test_xml_discovery_plugin.py
+++ b/tests/plugins/discovery/xml_discovery_plugin/test_xml_discovery_plugin.py
@@ -19,7 +19,9 @@ def test_xml_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "xml"

--- a/tests/plugins/discovery/yaml_discovery_plugin/test_yaml_discovery_plugin.py
+++ b/tests/plugins/discovery/yaml_discovery_plugin/test_yaml_discovery_plugin.py
@@ -19,7 +19,9 @@ def test_yaml_discovery_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Discovery": DiscoveryPlugin,}
+        {
+            "Discovery": DiscoveryPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "yaml"

--- a/tests/plugins/reporting/print_to_console_reporting_plugin/test_print_to_console_reporting_plugin.py
+++ b/tests/plugins/reporting/print_to_console_reporting_plugin/test_print_to_console_reporting_plugin.py
@@ -21,7 +21,9 @@ def test_console_reporting_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Reporting": ReportingPlugin,}
+        {
+            "Reporting": ReportingPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "c"

--- a/tests/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin/test_write_jenkins_warnings_ng_reporting_plugin.py
+++ b/tests/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin/test_write_jenkins_warnings_ng_reporting_plugin.py
@@ -62,7 +62,9 @@ def test_write_jenkins_warnings_ng_reporting_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Reporting": ReportingPlugin,}
+        {
+            "Reporting": ReportingPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "c"

--- a/tests/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin/test_write_jenkins_warnings_ng_reporting_plugin.py
+++ b/tests/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin/test_write_jenkins_warnings_ng_reporting_plugin.py
@@ -20,9 +20,9 @@ from statick_tool.resources import Resources
 try:
     from tempfile import TemporaryDirectory
 except:  # pylint: disable=bare-except # noqa: E722 # NOLINT
-    from backports.tempfile import (
+    from backports.tempfile import (  # pylint: disable=wrong-import-order
         TemporaryDirectory,
-    )  # pylint: disable=wrong-import-order
+    )
 
 output_regex = r"^{\"(.*)\": \"(.*)\", \"(.*)\": \"(.*)\", \"(.*)\": (\d+), \"(.*)\": \"(.*)\", \"(.*)\": \"(.*)\", \"(.*)\": \"(.*)\"}"
 

--- a/tests/plugins/tool/bandit_tool_plugin/test_bandit_tool_plugin.py
+++ b/tests/plugins/tool/bandit_tool_plugin/test_bandit_tool_plugin.py
@@ -51,7 +51,9 @@ def test_bandit_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "bandit"

--- a/tests/plugins/tool/black_tool_plugin/test_black_tool_plugin.py
+++ b/tests/plugins/tool/black_tool_plugin/test_black_tool_plugin.py
@@ -46,7 +46,9 @@ def test_black_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "black"

--- a/tests/plugins/tool/catkin-lint_tool_plugin/test_catkin-lint_tool_plugin.py
+++ b/tests/plugins/tool/catkin-lint_tool_plugin/test_catkin-lint_tool_plugin.py
@@ -46,7 +46,9 @@ def test_catkin_lint_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "catkin_lint"

--- a/tests/plugins/tool/cccc_tool_plugin/test_cccc_tool_plugin.py
+++ b/tests/plugins/tool/cccc_tool_plugin/test_cccc_tool_plugin.py
@@ -58,7 +58,9 @@ def test_cccc_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "cccc"

--- a/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
+++ b/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
@@ -65,7 +65,9 @@ def test_clang_format_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "clang_format"

--- a/tests/plugins/tool/clang-tidy_tool_plugin/test_clang-tidy_tool_plugin.py
+++ b/tests/plugins/tool/clang-tidy_tool_plugin/test_clang-tidy_tool_plugin.py
@@ -18,9 +18,9 @@ from statick_tool.tool_plugin import ToolPlugin
 try:
     from tempfile import TemporaryDirectory
 except:  # pylint: disable=bare-except # noqa: E722 # NOLINT
-    from backports.tempfile import (
+    from backports.tempfile import (  # pylint: disable=wrong-import-order
         TemporaryDirectory,
-    )  # pylint: disable=wrong-import-order
+    )
 
 
 def setup_clang_tidy_tool_plugin(use_plugin_context=True, binary=None):

--- a/tests/plugins/tool/clang-tidy_tool_plugin/test_clang-tidy_tool_plugin.py
+++ b/tests/plugins/tool/clang-tidy_tool_plugin/test_clang-tidy_tool_plugin.py
@@ -60,7 +60,9 @@ def test_clang_tidy_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "clang_tidy"

--- a/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
+++ b/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
@@ -45,7 +45,9 @@ def test_cmakelint_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "cmakelint"

--- a/tests/plugins/tool/cppcheck_tool_plugin/test_cppcheck_tool_plugin.py
+++ b/tests/plugins/tool/cppcheck_tool_plugin/test_cppcheck_tool_plugin.py
@@ -53,7 +53,9 @@ def test_cppcheck_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "cppcheck"

--- a/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
+++ b/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
@@ -54,7 +54,9 @@ def test_cpplint_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "cpplint"

--- a/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
+++ b/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
@@ -19,9 +19,9 @@ from statick_tool.tool_plugin import ToolPlugin
 try:
     from tempfile import TemporaryDirectory
 except:  # pylint: disable=bare-except # noqa: E722 # NOLINT
-    from backports.tempfile import (
+    from backports.tempfile import (  # pylint: disable=wrong-import-order
         TemporaryDirectory,
-    )  # pylint: disable=wrong-import-order
+    )
 
 
 def setup_cpplint_tool_plugin():

--- a/tests/plugins/tool/docformatter_tool_plugin/test_docformatter_tool_plugin.py
+++ b/tests/plugins/tool/docformatter_tool_plugin/test_docformatter_tool_plugin.py
@@ -46,7 +46,9 @@ def test_docformatter_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "docformatter"

--- a/tests/plugins/tool/flawfinder_tool_plugin/test_flawfinder_tool_plugin.py
+++ b/tests/plugins/tool/flawfinder_tool_plugin/test_flawfinder_tool_plugin.py
@@ -51,7 +51,9 @@ def test_flawfinder_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "flawfinder"

--- a/tests/plugins/tool/lizard_tool_plugin/test_lizard_tool_plugin.py
+++ b/tests/plugins/tool/lizard_tool_plugin/test_lizard_tool_plugin.py
@@ -46,7 +46,9 @@ def test_lizard_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "lizard"
@@ -88,8 +90,10 @@ def test_lizard_tool_plugin_scan_valid():
 def test_lizard_tool_plugin_parse_valid():
     """Verify that we can parse the normal output of lizard."""
     ltp = setup_lizard_tool_plugin()
-    output = "{}:1: warning: func has 22 NLOC, 18 CCN, 143 token, 0 PARAM, 69 length".format(
-        os.path.join("valid_package", "test.c")
+    output = (
+        "{}:1: warning: func has 22 NLOC, 18 CCN, 143 token, 0 PARAM, 69 length".format(
+            os.path.join("valid_package", "test.c")
+        )
     )
     issues = ltp.parse_output(output)
     assert len(issues) == 1

--- a/tests/plugins/tool/make_tool_plugin/test_make_tool_plugin.py
+++ b/tests/plugins/tool/make_tool_plugin/test_make_tool_plugin.py
@@ -49,7 +49,9 @@ def test_make_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "make"

--- a/tests/plugins/tool/mypy_tool_plugin/test_mypy_tool_plugin.py
+++ b/tests/plugins/tool/mypy_tool_plugin/test_mypy_tool_plugin.py
@@ -46,7 +46,9 @@ def test_mypy_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "mypy"

--- a/tests/plugins/tool/perlcritic_tool_plugin/test_perlcritic_tool_plugin.py
+++ b/tests/plugins/tool/perlcritic_tool_plugin/test_perlcritic_tool_plugin.py
@@ -52,7 +52,9 @@ def test_perlcritic_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "perlcritic"

--- a/tests/plugins/tool/pycodestyle_tool_plugin/test_pycodestyle_tool_plugin.py
+++ b/tests/plugins/tool/pycodestyle_tool_plugin/test_pycodestyle_tool_plugin.py
@@ -45,7 +45,9 @@ def test_pycodestyle_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "pycodestyle"

--- a/tests/plugins/tool/pydocstyle_tool_plugin/test_pydocstyle_tool_plugin.py
+++ b/tests/plugins/tool/pydocstyle_tool_plugin/test_pydocstyle_tool_plugin.py
@@ -45,7 +45,9 @@ def test_pydocstyle_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "pydocstyle"

--- a/tests/plugins/tool/pyflakes_tool_plugin/test_pyflakes_tool_plugin.py
+++ b/tests/plugins/tool/pyflakes_tool_plugin/test_pyflakes_tool_plugin.py
@@ -45,7 +45,9 @@ def test_pyflakes_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "pyflakes"

--- a/tests/plugins/tool/pylint_tool_plugin/test_pylint_tool_plugin.py
+++ b/tests/plugins/tool/pylint_tool_plugin/test_pylint_tool_plugin.py
@@ -45,7 +45,9 @@ def test_pylint_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "pylint"

--- a/tests/plugins/tool/spotbugs_tool_plugin/test_spotbugs_tool_plugin.py
+++ b/tests/plugins/tool/spotbugs_tool_plugin/test_spotbugs_tool_plugin.py
@@ -54,7 +54,9 @@ def test_spotbugs_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "spotbugs"

--- a/tests/plugins/tool/uncrustify_tool_plugin/test_uncrustify_tool_plugin.py
+++ b/tests/plugins/tool/uncrustify_tool_plugin/test_uncrustify_tool_plugin.py
@@ -59,7 +59,9 @@ def test_uncrustify_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "uncrustify"

--- a/tests/plugins/tool/uncrustify_tool_plugin/test_uncrustify_tool_plugin.py
+++ b/tests/plugins/tool/uncrustify_tool_plugin/test_uncrustify_tool_plugin.py
@@ -18,9 +18,9 @@ from statick_tool.tool_plugin import ToolPlugin
 try:
     from tempfile import TemporaryDirectory
 except:  # pylint: disable=bare-except # noqa: E722 # NOLINT
-    from backports.tempfile import (
+    from backports.tempfile import (  # pylint: disable=wrong-import-order
         TemporaryDirectory,
-    )  # pylint: disable=wrong-import-order
+    )
 
 
 def setup_uncrustify_tool_plugin(extra_path=None, use_plugin_context=True, binary=None):

--- a/tests/plugins/tool/xmllint_tool_plugin/test_xmllint_tool_plugin.py
+++ b/tests/plugins/tool/xmllint_tool_plugin/test_xmllint_tool_plugin.py
@@ -46,7 +46,9 @@ def test_xmllint_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "xmllint"

--- a/tests/plugins/tool/yamllint_tool_plugin/test_yamllint_tool_plugin.py
+++ b/tests/plugins/tool/yamllint_tool_plugin/test_yamllint_tool_plugin.py
@@ -46,7 +46,9 @@ def test_yamllint_tool_plugin_found():
         [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
     )
     manager.setCategoriesFilter(
-        {"Tool": ToolPlugin,}
+        {
+            "Tool": ToolPlugin,
+        }
     )
     manager.collectPlugins()
     # Verify that a plugin's get_name() function returns "yamllint"

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -9,9 +9,9 @@ from statick_tool.resources import Resources
 try:
     from tempfile import TemporaryDirectory
 except:  # pylint: disable=bare-except # noqa: E722 # NOLINT
-    from backports.tempfile import (
+    from backports.tempfile import (  # pylint: disable=wrong-import-order
         TemporaryDirectory,
-    )  # pylint: disable=wrong-import-order
+    )
 
 
 def test_resources_init():

--- a/tests/tool_plugin/test_tool_plugin.py
+++ b/tests/tool_plugin/test_tool_plugin.py
@@ -15,9 +15,9 @@ from statick_tool.tool_plugin import ToolPlugin
 try:
     from tempfile import TemporaryDirectory
 except:  # pylint: disable=bare-except # noqa: E722 # NOLINT
-    from backports.tempfile import (
+    from backports.tempfile import (  # pylint: disable=wrong-import-order
         TemporaryDirectory,
-    )  # pylint: disable=wrong-import-order
+    )
 
 
 def test_tool_plugin_load_mapping_valid():


### PR DESCRIPTION
* Format all Python files with latest version of black (version 20.8b1).
* Add `from` keyword when re-raising exceptions
  * pylint W0707: raise-missing-from
  * https://pylint.readthedocs.io/en/latest/technical_reference/features.html