### PR TITLE
Fixes for running cmake_discovery_plugin with some ROS 2 packages that contain messages.

### DIFF
--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -119,7 +119,7 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
     ) -> None:
         """Parse the tool output."""
         # pylint: disable=anomalous-backslash-in-string
-        cmake_target_re = r"-- TARGET: \[NAME:(.+)\]\[SRC_DIR:(.+)\]\[INCLUDE_DIRS:(.+)\]\[SRC:(.+)\]"  # NOQA: W605 # NOLINT
+        cmake_target_re = r"-- TARGET: \[NAME:(.+)\]\[SRC_DIR:(.+)\]\[INCLUDE_DIRS:(.*)\]\[SRC:(.+)\]"  # NOQA: W605 # NOLINT
         target_p = re.compile(cmake_target_re)  # type: Pattern[str]
         cmake_headers_re = r"-- HEADERS: (.+)"
         headers_p = re.compile(cmake_headers_re)  # type: Pattern[str]

--- a/statick_tool/rsc/CMakeLists.txt.in
+++ b/statick_tool/rsc/CMakeLists.txt.in
@@ -53,7 +53,10 @@ function(add_statick_target)
 
   get_directory_property(TARGET_INCLUDE_DIRS INCLUDE_DIRECTORIES)
 
-  get_target_property(TARGET_SOURCES ${ARGV0} SOURCES)
+  get_target_property(TARGET_TYPE ${ARGV0} TYPE)
+  if (NOT ${TARGET_TYPE} MATCHES ".*INTERFACE.*")
+    get_target_property(TARGET_SOURCES ${ARGV0} SOURCES)
+  endif()
 
   message(STATUS "TARGET: [NAME:${ARGV0}][SRC_DIR:${CMAKE_CURRENT_SOURCE_DIR}][INCLUDE_DIRS:${TARGET_INCLUDE_DIRS}][SRC:${TARGET_SOURCES}]")
 

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -125,7 +125,9 @@ def test_cmake_discovery_plugin_check_output_target():
     )
     package["make_targets"] = []
     output = "-- TARGET: [NAME:foo][SRC_DIR:foo/src/][INCLUDE_DIRS:include/foo/][SRC:foo.cpp]"
-    output += "\n-- TARGET: [NAME:foo_lib][SRC_DIR:foo/src/][INCLUDE_DIRS:][SRC:foo.cpp]"
+    output += (
+        "\n-- TARGET: [NAME:foo_lib][SRC_DIR:foo/src/][INCLUDE_DIRS:][SRC:foo.cpp]"
+    )
     cmdp.process_output(output, package)
     assert package["make_targets"][0]["name"] == "foo"
     assert package["make_targets"][0]["src_dir"] == "foo/src/"

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -125,11 +125,16 @@ def test_cmake_discovery_plugin_check_output_target():
     )
     package["make_targets"] = []
     output = "-- TARGET: [NAME:foo][SRC_DIR:foo/src/][INCLUDE_DIRS:include/foo/][SRC:foo.cpp]"
+    output += "\n-- TARGET: [NAME:foo_lib][SRC_DIR:foo/src/][INCLUDE_DIRS:][SRC:foo.cpp]"
     cmdp.process_output(output, package)
     assert package["make_targets"][0]["name"] == "foo"
     assert package["make_targets"][0]["src_dir"] == "foo/src/"
     assert package["make_targets"][0]["include_dirs"] == ["include/foo/"]
     assert package["make_targets"][0]["src"] == ["foo/src/foo.cpp"]
+    assert package["make_targets"][1]["name"] == "foo_lib"
+    assert package["make_targets"][1]["src_dir"] == "foo/src/"
+    assert package["make_targets"][1]["include_dirs"] == [""]
+    assert package["make_targets"][1]["src"] == ["foo/src/foo.cpp"]
 
 
 def test_cmake_discovery_plugin_check_output_project():


### PR DESCRIPTION
I've also had to add the following argument to my statick invocations: `--cmake-flags="-DCMAKE_PREFIX_PATH=/opt/ros/foxy"`

Steps to recreate:
```
git clone https://github.com/Liquid-ai/Plankton.git
cd Plankton
statick uuv_world_plugins/uuv_world_ros_plugins_msgs --output-directory /tmp/statick-output   --cmake-flags="-DCMAKE_PREFIX_PATH=/opt/ros/foxy" --force-tool-list make
```