### PR TITLE
Swap order of checks in cpplint for package information. This will ca…

### DIFF
--- a/statick_tool/plugins/tool/cpplint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cpplint_tool_plugin.py
@@ -18,12 +18,12 @@ class CpplintToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
+        if "make_targets" not in package and "headers" not in package:
+            return []
+
         if "cpplint" not in package:
             print("  cpplint not found!")
             return None
-
-        if "make_targets" not in package and "headers" not in package:
-            return []
 
         flags = []  # type: List[str]
         flags += self.get_user_flags(level)

--- a/statick_tool/plugins/tool/cpplint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cpplint_tool_plugin.py
@@ -21,6 +21,9 @@ class CpplintToolPlugin(ToolPlugin):
         if "make_targets" not in package and "headers" not in package:
             return []
 
+        if not package["make_targets"] and not package["headers"]:
+            return []
+
         if "cpplint" not in package:
             print("  cpplint not found!")
             return None

--- a/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
+++ b/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
@@ -158,15 +158,32 @@ def test_cpplint_tool_plugin_scan_missing_fields():
     Expected result: issues is None then empty
     """
     ctp = setup_cpplint_tool_plugin()
+
+    # Missing tool name in package.
     package = Package(
         "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
     )
-    # Missing tool name in package.
+    package["make_targets"] = []
+    package["make_targets"].append({})
+    package["make_targets"][0]["src"] = [
+        os.path.join(os.path.dirname(__file__), "valid_package", "test.c")
+    ]
     issues = ctp.scan(package, "level")
     assert issues is None
 
-    # Missing make_targets and headers in package
-    package["cpplint"] = "cpplint"
+    # Empty make_targets and headers in package.
+    package = Package(
+        "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
+    )
+    package["make_targets"] = []
+    package["headers"] = []
+    issues = ctp.scan(package, "level")
+    assert not issues
+
+    # Missing make_targets and headers in package.
+    package = Package(
+        "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
+    )
     issues = ctp.scan(package, "level")
     assert not issues
 


### PR DESCRIPTION
…use saner output for users when there are no C/C++ files found.