### PR TITLE
Multiprocess statick_ws

### DIFF
--- a/statick_ws
+++ b/statick_ws
@@ -3,6 +3,7 @@
 
 from __future__ import print_function
 
+import argparse
 import multiprocessing
 import os
 import sys
@@ -15,7 +16,7 @@ from statick_tool.plugin_context import PluginContext
 from statick_tool.statick import Statick
 
 
-def scan_package(statick, parsed_args, count, package, num_packages):
+def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, package: Package, num_packages: int) -> Dict[str, List[Issue]]:
     print(
         "-- Scanning package "
         + package[0]
@@ -45,7 +46,7 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
     """Run statick_ws."""
     args = Args("Statick workspace tool")
     args.parser.add_argument("path", help="Path of workspace to scan")
-    args.parser.add_argument("--max_threads", type=int, default=int(multiprocessing.cpu_count()/2), help="Maximum number of threads")
+    args.parser.add_argument("--max_procs", type=int, default=int(multiprocessing.cpu_count()/2), help="Maximum number of procs")
     args.parser.add_argument(
         "--packages-file",
         dest="packages_file",
@@ -112,7 +113,6 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
     else:
         count = 0
         total_issues = []
-        threads = []  # type: List[Thread]
         issues = {}  # type: Optional[Dict[str, List[Issue]]]
         num_packages = len(packages)
         mp_args = []
@@ -120,7 +120,7 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
             count += 1
             mp_args.append((statick, parsed_args, count, package, num_packages))
 
-        with multiprocessing.Pool(parsed_args.max_threads) as pool:
+        with multiprocessing.Pool(parsed_args.max_procs) as pool:
             total_issues = pool.starmap(scan_package, mp_args)
 
     if parsed_args.list_packages:

--- a/statick_ws
+++ b/statick_ws
@@ -17,7 +17,13 @@ from statick_tool.plugin_context import PluginContext
 from statick_tool.statick import Statick
 
 
-def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, package: Package, num_packages: int) -> Dict[str, List[Issue]]:
+def scan_package(
+    statick: Statick,
+    parsed_args: argparse.Namespace,
+    count: int,
+    package: Package,
+    num_packages: int,
+) -> Dict[str, List[Issue]]:
     """Function used by multiprocess to scan each package in a separate process while buffering output."""
     sio = io.StringIO()
     old_stdout = sys.stdout
@@ -55,11 +61,17 @@ def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, 
         sys.exit(1)
     return issues
 
+
 def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     """Run statick_ws."""
     args = Args("Statick workspace tool")
     args.parser.add_argument("path", help="Path of workspace to scan")
-    args.parser.add_argument("--max_procs", type=int, default=int(multiprocessing.cpu_count()/2), help="Maximum number of procs")
+    args.parser.add_argument(
+        "--max_procs",
+        type=int,
+        default=int(multiprocessing.cpu_count() / 2),
+        help="Maximum number of procs",
+    )
     args.parser.add_argument(
         "--packages-file",
         dest="packages_file",

--- a/statick_ws
+++ b/statick_ws
@@ -3,6 +3,7 @@
 
 from __future__ import print_function
 
+import multiprocessing
 import os
 import sys
 from typing import Dict, List, Optional
@@ -14,10 +15,37 @@ from statick_tool.plugin_context import PluginContext
 from statick_tool.statick import Statick
 
 
+def scan_package(statick, parsed_args, count, package, num_packages):
+    print(
+        "-- Scanning package "
+        + package[0]
+        + " ("
+        + str(count)
+        + " of "
+        + str(num_packages)
+        + ") --"
+    )
+    issues, dummy = statick.run(package[1], parsed_args)
+    if issues is not None:
+        print(
+            "-- Done scanning package "
+            + package[0]
+            + " ("
+            + str(count)
+            + " of "
+            + str(num_packages)
+            + ") --"
+        )
+        return issues
+    else:
+        print("Failed to run statick on package " + package[0] + "!")
+        sys.exit(1)
+
 def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     """Run statick_ws."""
     args = Args("Statick workspace tool")
     args.parser.add_argument("path", help="Path of workspace to scan")
+    args.parser.add_argument("--max_threads", type=int, default=int(multiprocessing.cpu_count()/2), help="Maximum number of threads")
     args.parser.add_argument(
         "--packages-file",
         dest="packages_file",
@@ -76,41 +104,24 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
             sys.exit(1)
         packages = [package for package in packages if package[0] in packages_file_list]
 
-    count = 0
-    total_issues = []
-    issues = {}  # type: Optional[Dict[str, List[Issue]]]
-    for package in packages:
-        if parsed_args.list_packages:
-            print(
-                "%-40s: %s" % (package[0], statick.get_level(package[1], parsed_args))
-            )
-            continue
+    if parsed_args.list_packages:
+        for package in packages:
+                print(
+                    "%-40s: %s" % (package[0], statick.get_level(package[1], parsed_args))
+                )
+    else:
+        count = 0
+        total_issues = []
+        threads = []  # type: List[Thread]
+        issues = {}  # type: Optional[Dict[str, List[Issue]]]
+        num_packages = len(packages)
+        mp_args = []
+        for package in packages:
+            count += 1
+            mp_args.append((statick, parsed_args, count, package, num_packages))
 
-        count += 1
-        print(
-            "-- Scanning package "
-            + package[0]
-            + " ("
-            + str(count)
-            + " of "
-            + str(len(packages))
-            + ") --"
-        )
-        issues, dummy = statick.run(package[1], parsed_args)
-        if issues is not None:
-            total_issues.append(issues)
-        else:
-            print("Failed to run statick on package " + package[0] + "!")
-            sys.exit(1)
-        print(
-            "-- Done scanning package "
-            + package[0]
-            + " ("
-            + str(count)
-            + " of "
-            + str(len(packages))
-            + ") --"
-        )
+        with multiprocessing.Pool(parsed_args.max_threads) as pool:
+            total_issues = pool.starmap(scan_package, mp_args)
 
     if parsed_args.list_packages:
         sys.exit(0)

--- a/statick_ws
+++ b/statick_ws
@@ -4,6 +4,7 @@
 from __future__ import print_function
 
 import argparse
+import io
 import multiprocessing
 import os
 import sys
@@ -17,6 +18,11 @@ from statick_tool.statick import Statick
 
 
 def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, package: Package, num_packages: int) -> Dict[str, List[Issue]]:
+    sio = io.StringIO()
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    sys.stdout = sio
+    sys.stderr = sio
     print(
         "-- Scanning package "
         + package[0]
@@ -37,9 +43,15 @@ def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, 
             + str(num_packages)
             + ") --"
         )
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        print(sio.getvalue(), flush=True)
         return issues
     else:
         print("Failed to run statick on package " + package[0] + "!")
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+        print(sio.getvalue(), flush=True)
         sys.exit(1)
 
 def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
@@ -120,6 +132,7 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
             count += 1
             mp_args.append((statick, parsed_args, count, package, num_packages))
 
+        print("-- Scanning {} packages --".format(num_packages))
         with multiprocessing.Pool(parsed_args.max_procs) as pool:
             total_issues = pool.starmap(scan_package, mp_args)
 

--- a/statick_ws
+++ b/statick_ws
@@ -64,11 +64,18 @@ def scan_package(
 
 
 def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
-    """Run statick_ws."""
+    """
+    Run statick_ws.
+
+    --max-procs can be set to the desired number of CPUs to use for processing a workspace.
+    This defaults to half the available CPUs.
+    Setting this to -1 will cause statick_ws to use all available CPUs.
+    """
     args = Args("Statick workspace tool")
     args.parser.add_argument("path", help="Path of workspace to scan")
     args.parser.add_argument(
-        "--max_procs",
+        "--max-procs",
+        dest="max_procs",
         type=int,
         default=int(multiprocessing.cpu_count() / 2),
         help="Maximum number of procs",
@@ -91,6 +98,11 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
     parsed_args = args.get_args()
     statick.get_config(parsed_args)
     statick.get_exceptions(parsed_args)
+
+    if parsed_args.max_procs == -1:
+        parsed_args.max_procs = multiprocessing.cpu_count()
+    elif parsed_args.max_procs <= 0:
+        parsed_args.max_procs = 1
 
     if parsed_args.output_directory:
         out_dir = parsed_args.output_directory
@@ -146,7 +158,7 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
             count += 1
             mp_args.append((statick, parsed_args, count, package, num_packages))
 
-        print("-- Scanning {} packages --".format(num_packages))
+        print("-- Scanning {} packages --".format(num_packages), flush=True)
         with multiprocessing.Pool(parsed_args.max_procs) as pool:
             total_issues = pool.starmap(scan_package, mp_args)
 

--- a/statick_ws
+++ b/statick_ws
@@ -78,7 +78,7 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
         dest="max_procs",
         type=int,
         default=int(multiprocessing.cpu_count() / 2),
-        help="Maximum number of procs",
+        help="Maximum number of CPU cores to use",
     )
     args.parser.add_argument(
         "--packages-file",
@@ -99,8 +99,9 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
     statick.get_config(parsed_args)
     statick.get_exceptions(parsed_args)
 
-    if parsed_args.max_procs == -1:
-        parsed_args.max_procs = multiprocessing.cpu_count()
+    max_cpus = multiprocessing.cpu_count()
+    if parsed_args.max_procs > max_cpus or parsed_args.max_procs == -1:
+        parsed_args.max_procs = max_cpus
     elif parsed_args.max_procs <= 0:
         parsed_args.max_procs = 1
 

--- a/statick_ws
+++ b/statick_ws
@@ -24,7 +24,8 @@ def scan_package(
     package: Package,
     num_packages: int,
 ) -> Dict[str, List[Issue]]:
-    """Function used by multiprocess to scan each package in a separate process while buffering output."""
+    """Function used by multiprocess to scan each package in a separate process while
+    buffering output."""
     sio = io.StringIO()
     old_stdout = sys.stdout
     old_stderr = sys.stderr

--- a/statick_ws
+++ b/statick_ws
@@ -18,6 +18,7 @@ from statick_tool.statick import Statick
 
 
 def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, package: Package, num_packages: int) -> Dict[str, List[Issue]]:
+    """Function used by multiprocess to scan each package in a separate process while buffering output."""
     sio = io.StringIO()
     old_stdout = sys.stdout
     old_stderr = sys.stderr
@@ -46,13 +47,13 @@ def scan_package(statick: Statick, parsed_args: argparse.Namespace, count: int, 
         sys.stdout = old_stdout
         sys.stderr = old_stderr
         print(sio.getvalue(), flush=True)
-        return issues
     else:
         print("Failed to run statick on package " + package[0] + "!")
         sys.stdout = old_stdout
         sys.stderr = old_stderr
         print(sio.getvalue(), flush=True)
         sys.exit(1)
+    return issues
 
 def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
     """Run statick_ws."""
@@ -119,9 +120,9 @@ def main() -> None:  # pylint: disable=too-many-locals, too-many-branches, too-m
 
     if parsed_args.list_packages:
         for package in packages:
-                print(
-                    "%-40s: %s" % (package[0], statick.get_level(package[1], parsed_args))
-                )
+            print(
+                "%-40s: %s" % (package[0], statick.get_level(package[1], parsed_args))
+            )
     else:
         count = 0
         total_issues = []


### PR DESCRIPTION
This works, and runs faster than the master branch. However I cannot figure out how (or indeed if it's even possible) to make the package count incrementally increase (i.e. to maintain a count of where in the list of packages statick is).

On this workspace I see the below difference in timings: https://github.com/Field-Robotics-Lab/dave/blob/master/repos/dave_sim.repos
`time statick_ws src --output-directory /tmp/statick-output`
master:
Statick exiting with success.

real	0m21.468s
user	0m17.024s
sys	0m5.003s

issue:
Statick exiting with success.

real	0m4.316s
user	0m18.927s
sys	0m5.157s
