### PR TITLE
Only outputting warning about docformatter failing if returncode is n…

### DIFF
--- a/statick_tool/plugins/tool/docformatter_tool_plugin.py
+++ b/statick_tool/plugins/tool/docformatter_tool_plugin.py
@@ -42,11 +42,13 @@ class DocformatterToolPlugin(ToolPlugin):
                 return []
 
             except subprocess.CalledProcessError as ex:
-                logging.warning("docformatter binary failed: %s.", tool_bin)
-                logging.warning("Returncode: %d", ex.returncode)
-                logging.warning("%s exception: %s", self.get_name(), ex.output)
-                total_output.append(ex.output)
-                continue
+                if ex.returncode == 3:
+                    total_output.append(ex.output)
+                else:
+                    logging.warning("docformatter binary failed: %s.", tool_bin)
+                    logging.warning("Returncode: %d", ex.returncode)
+                    logging.warning("%s exception: %s", self.get_name(), ex.output)
+                    continue
 
         for output in total_output:
             logging.debug("%s", output)
@@ -80,7 +82,7 @@ class DocformatterToolPlugin(ToolPlugin):
                             self.get_name(),
                             "format",
                             "3",
-                            "docformatter",
+                            "would reformat",
                             None,
                         )
                     )

--- a/tests/plugins/tool/docformatter_tool_plugin/test_docformatter_tool_plugin.py
+++ b/tests/plugins/tool/docformatter_tool_plugin/test_docformatter_tool_plugin.py
@@ -95,7 +95,7 @@ def test_docformatter_tool_plugin_parse_valid():
     assert issues[0].tool == "docformatter"
     assert issues[0].issue_type == "format"
     assert issues[0].severity == "3"
-    assert issues[0].message == "docformatter"
+    assert issues[0].message == "would reformat"
 
 
 def test_docformatter_tool_plugin_parse_invalid():


### PR DESCRIPTION
…ot 3, which is used to indicate that files would be formatted.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>

Fixes #333 