### PR TITLE
Switch type hints from comment style to inline style. 

### DIFF
--- a/statick_tool/args.py
+++ b/statick_tool/args.py
@@ -30,10 +30,10 @@ class Args:
 
     def get_user_paths(self, args: Any = None) -> List[str]:
         """Get a list of user paths containing config or plugins."""
-        user_paths = []  # type: List[str]
+        user_paths: List[str] = []
         args = self.pre_parser.parse_known_args(args)[0]
         if args.user_paths is not None:
-            paths = args.user_paths.split(",")  # type: List[str]
+            paths: List[str] = args.user_paths.split(",")
             for path in paths:
                 if os.path.exists(path) and os.path.isdir(path):
                     user_paths.append(path)

--- a/statick_tool/config.py
+++ b/statick_tool/config.py
@@ -18,7 +18,7 @@ class Config:
     def __init__(self, base_file: Optional[str], user_file: Optional[str] = "") -> None:
         """Initialize configuration."""
         if base_file is None or not os.path.exists(base_file):
-            self.config = []  # type: Any
+            self.config: Any = []
             return
 
         self.config = self.get_config_from_file(base_file)
@@ -66,7 +66,7 @@ class Config:
     def get_enabled_plugins(self, level: str, plugin_type: str) -> List[str]:
         """Get what plugins are enabled for a certain level."""
         level_config = self.config["levels"][level]
-        plugins = []  # type: List[str]
+        plugins: List[str] = []
         if plugin_type in level_config and level_config[plugin_type] is not None:
             plugins += list(level_config[plugin_type])
         if "inherits_from" in level_config:

--- a/statick_tool/discovery_plugin.py
+++ b/statick_tool/discovery_plugin.py
@@ -74,9 +74,9 @@ class DiscoveryPlugin(IPlugin):  # type: ignore
             return ""
 
         try:
-            output = subprocess.check_output(
+            output: str = subprocess.check_output(
                 ["file", full_path], universal_newlines=True
-            )  # type: str
+            )
             return output.lower()
         except subprocess.CalledProcessError as ex:
             logging.warning(

--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -31,7 +31,7 @@ class Exceptions:
             raise ValueError("{} is not a valid file".format(filename))
         with open(filename) as fname:
             try:
-                self.exceptions = yaml.safe_load(fname)  # type: Dict[Any, Any]
+                self.exceptions: Dict[Any, Any] = yaml.safe_load(fname)
             except (yaml.YAMLError, yaml.scanner.ScannerError) as ex:
                 raise ValueError(
                     "{} is not a valid YAML file: {}".format(filename, ex)
@@ -39,7 +39,7 @@ class Exceptions:
 
     def get_ignore_packages(self) -> List[str]:
         """Get list of packages to skip when scanning a workspace."""
-        ignore = []  # type: List[str]
+        ignore: List[str] = []
         if (
             "ignore_packages" in self.exceptions
             and self.exceptions["ignore_packages"] is not None
@@ -49,7 +49,7 @@ class Exceptions:
 
     def get_exceptions(self, package: Package) -> Dict[Any, Any]:
         """Get specific exceptions for given package."""
-        exceptions = {"file": [], "message_regex": []}  # type: Dict[Any, Any]
+        exceptions: Dict[Any, Any] = {"file": [], "message_regex": []}
 
         if "global" in self.exceptions and "exceptions" in self.exceptions["global"]:
             global_exceptions = self.exceptions["global"]["exceptions"]
@@ -88,7 +88,7 @@ class Exceptions:
         plugins have been run (so that Statick doesn't run the tool plugins against
         files which will be ignored anyway).
         """
-        exceptions = self.get_exceptions(package)  # type: Dict[Any, Any]
+        exceptions: Dict[Any, Any] = self.get_exceptions(package)
         to_remove = []
         for filename in file_list:
             removed = False
@@ -117,20 +117,20 @@ class Exceptions:
             issues.items()
         ):
             warning_printed = False
-            to_remove = []  # type: List[Issue]
+            to_remove: List[Issue] = []
             for issue in tool_issues:
                 if not os.path.isabs(issue.filename):
                     if not warning_printed:
                         self.print_exception_warning(tool)
                         warning_printed = True
                     continue
-                rel_path = os.path.relpath(issue.filename, package.path)  # type: str
+                rel_path: str = os.path.relpath(issue.filename, package.path)
                 for exception in exceptions:
                     if exception["tools"] == "all" or tool in exception["tools"]:
                         for pattern in exception["globs"]:
                             # Hack to avoid exceptions for everything on Travis CI.
-                            fname = issue.filename  # type: str
-                            prefix = "/home/travis/build/"  # type: str
+                            fname: str = issue.filename
+                            prefix: str = "/home/travis/build/"
                             if pattern == "*/build/*" and fname.startswith(prefix):
                                 fname = fname[len(prefix) :]
                             if fnmatch.fnmatch(fname, pattern) or fnmatch.fnmatch(
@@ -153,7 +153,7 @@ class Exceptions:
             if "globs" in exception:
                 exception_globs = exception["globs"]
             try:
-                compiled_re = re.compile(exception_re)  # type: Pattern[str]
+                compiled_re: Pattern[str] = re.compile(exception_re)
             except re.error:
                 logging.warning(
                     "Invalid regular expression in exception: %s", exception_re
@@ -166,15 +166,15 @@ class Exceptions:
                         if exception_globs:
                             for pattern in exception_globs:
                                 if fnmatch.fnmatch(issue.filename, pattern):
-                                    match = compiled_re.match(
+                                    match: Optional[Match[str]] = compiled_re.match(
                                         issue.message
-                                    )  # type: Optional[Match[str]]
+                                    )
                                     if match:
                                         to_remove.append(issue)
                         else:
-                            match_re = compiled_re.match(
+                            match_re: Optional[Match[str]] = compiled_re.match(
                                 issue.message
-                            )  # type: Optional[Match[str]]
+                            )
                             if match_re:
                                 to_remove.append(issue)
                 issues[tool] = [
@@ -189,8 +189,8 @@ class Exceptions:
         complex macro or something.
         """
         for tool, tool_issues in list(issues.items()):
-            warning_printed = False  # type: bool
-            to_remove = []  # type: List[Issue]
+            warning_printed: bool = False
+            to_remove: List[Issue] = []
             for issue in tool_issues:
                 if not os.path.isabs(issue.filename):
                     if not warning_printed:

--- a/statick_tool/package.py
+++ b/statick_tool/package.py
@@ -12,5 +12,5 @@ class Package(dict):  # type: ignore
         """Initialize package interface."""
         self.name = name
         self.path = path
-        self.files = {}  # type: Dict[str, Dict[str, str]]
+        self.files: Dict[str, Dict[str, str]] = {}
         self._walked = False

--- a/statick_tool/plugins/discovery/c_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/c_discovery_plugin.py
@@ -19,7 +19,7 @@ class CDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for C files."""
-        c_files = []  # type: List[str]
+        c_files: List[str] = []
         c_extensions = (".c", ".cc", ".cpp", ".cxx", ".h", ".hxx", ".hpp")
         c_output = ("c source", "c program", "c++ source")
 

--- a/statick_tool/plugins/discovery/java_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/java_discovery_plugin.py
@@ -19,8 +19,8 @@ class JavaDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for java files."""
-        java_src_files = []  # type: List[str]
-        java_class_files = []  # type: List[str]
+        java_src_files: List[str] = []
+        java_class_files: List[str] = []
 
         self.find_files(package)
 

--- a/statick_tool/plugins/discovery/maven_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/maven_discovery_plugin.py
@@ -21,8 +21,8 @@ class MavenDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for maven files."""
-        top_poms = []  # type: List[str]
-        all_poms = []  # type: List[str]
+        top_poms: List[str] = []
+        all_poms: List[str] = []
         deepest_pom_level = 999999
 
         for root, _, files in os.walk(package.path):

--- a/statick_tool/plugins/discovery/perl_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/perl_discovery_plugin.py
@@ -19,7 +19,7 @@ class PerlDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for Perl files."""
-        perl_files = []  # type: List[str]
+        perl_files: List[str] = []
 
         self.find_files(package)
 

--- a/statick_tool/plugins/discovery/python_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/python_discovery_plugin.py
@@ -19,7 +19,7 @@ class PythonDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for python files."""
-        python_files = []  # type: List[str]
+        python_files: List[str] = []
 
         self.find_files(package)
 

--- a/statick_tool/plugins/discovery/shell_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/shell_discovery_plugin.py
@@ -19,7 +19,7 @@ class ShellDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for shell files."""
-        shell_files = []  # type: List[str]
+        shell_files: List[str] = []
         shell_extensions = (".sh", ".bash", ".zsh", ".csh", ".ksh", ".dash")
         shell_output = ("shell script", "dash script", "zsh script")
 

--- a/statick_tool/plugins/discovery/xml_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/xml_discovery_plugin.py
@@ -19,8 +19,8 @@ class XMLDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for XML files."""
-        xml_files = []  # type: List[str]
-        xml_extensions = (".xml", ".launch")  # type: Tuple[str, str]
+        xml_files: List[str] = []
+        xml_extensions: Tuple[str, str] = (".xml", ".launch")
 
         self.find_files(package)
 

--- a/statick_tool/plugins/discovery/yaml_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/yaml_discovery_plugin.py
@@ -19,7 +19,7 @@ class YAMLDiscoveryPlugin(DiscoveryPlugin):
         self, package: Package, level: str, exceptions: Optional[Exceptions] = None
     ) -> None:
         """Scan package looking for YAML files."""
-        yaml_files = []  # type: List[str]
+        yaml_files: List[str] = []
         yaml_extensions = (".yaml", ".yml")
 
         self.find_files(package)

--- a/statick_tool/plugins/reporting/print_to_console_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/print_to_console_reporting_plugin.py
@@ -26,7 +26,7 @@ class PrintToConsoleReportingPlugin(ReportingPlugin):
                 them.
             level: (:obj:`str`): Name of the level used in the scan
         """
-        total = 0  # type: int
+        total: int = 0
         for key, value in issues.items():
             unique_issues = list(OrderedDict.fromkeys(value))
             num_issues = len(unique_issues)

--- a/statick_tool/plugins/tool/bandit_tool_plugin.py
+++ b/statick_tool/plugins/tool/bandit_tool_plugin.py
@@ -30,14 +30,14 @@ class BanditToolPlugin(ToolPlugin):
         if not package["python_src"]:
             return []
 
-        bandit_bin = "bandit"  # type: str
+        bandit_bin: str = "bandit"
         if self.plugin_context and self.plugin_context.args.bandit_bin is not None:
             bandit_bin = self.plugin_context.args.bandit_bin
 
-        flags = ["--format=csv"]  # type: List[str]
+        flags: List[str] = ["--format=csv"]
         flags += self.get_user_flags(level)
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "python_src" in package:
             files += package["python_src"]
 
@@ -65,12 +65,12 @@ class BanditToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output.splitlines())
+        issues: List[Issue] = self.parse_output(output.splitlines())
         return issues
 
     def parse_output(self, output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
-        issues = []
+        issues: List[Issue] = []
 
         # Copy output for modification
         output_minus_log = list(output)

--- a/statick_tool/plugins/tool/black_tool_plugin.py
+++ b/statick_tool/plugins/tool/black_tool_plugin.py
@@ -18,11 +18,11 @@ class BlackToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
-        flags = ["--check"]
+        flags: List[str] = ["--check"]
         user_flags = self.get_user_flags(level)
         flags += user_flags
 
-        total_output = []
+        total_output: List[str] = []
 
         tool_bin = "black"
         for src in package["python_src"]:
@@ -59,29 +59,29 @@ class BlackToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         tool_re_reformat = r"(.+)\s(.+)\s(.+)"
-        parse_reformat = re.compile(tool_re_reformat)  # type: Pattern[str]
+        parse_reformat: Pattern[str] = re.compile(tool_re_reformat)
 
         # example output for this regex:
         # error: cannot format /home/user/file: INTERNAL ERROR: message
         tool_re_error = r"\w+:\s(.+):\s(.+):\s(.+):\s(.+)"
-        parse_tool_error = re.compile(tool_re_error)  # type: Pattern[str]
+        parse_tool_error: Pattern[str] = re.compile(tool_re_error)
 
         # example output for this regex:
         # error: cannot format /home/user/file: Cannot parse: 1:3: {faulty_line}
         tool_re_parse_error = r"\w+:\s(.+):\s(.+):\s([0-9]+):([0-9]+):\s(.+)"
-        parse_error = re.compile(tool_re_parse_error)  # type: Pattern[str]
-        issues = []
+        parse_error: Pattern[str] = re.compile(tool_re_parse_error)
+        issues: List[Issue] = []
 
         for output in total_output:
             for line in output.splitlines():
                 if line.startswith("would reformat"):
-                    match = parse_reformat.match(line)  # type: Optional[Match[str]]
+                    match: Optional[Match[str]] = parse_reformat.match(line)
                     if match:
                         issues.append(
                             Issue(
@@ -95,12 +95,12 @@ class BlackToolPlugin(ToolPlugin):
                             )
                         )
                 if line.startswith("error"):
-                    match_tool_error = parse_tool_error.match(
+                    match_tool_error: Optional[Match[str]] = parse_tool_error.match(
                         line
-                    )  # type: Optional[Match[str]]
-                    match_parse_error = parse_error.match(
+                    )
+                    match_parse_error: Optional[Match[str]] = parse_error.match(
                         line
-                    )  # type: Optional[Match[str]]
+                    )
                     if match_parse_error:
                         issues.append(
                             Issue(

--- a/statick_tool/plugins/tool/black_tool_plugin.py
+++ b/statick_tool/plugins/tool/black_tool_plugin.py
@@ -98,9 +98,7 @@ class BlackToolPlugin(ToolPlugin):
                     match_tool_error: Optional[Match[str]] = parse_tool_error.match(
                         line
                     )
-                    match_parse_error: Optional[Match[str]] = parse_error.match(
-                        line
-                    )
+                    match_parse_error: Optional[Match[str]] = parse_error.match(line)
                     if match_parse_error:
                         issues.append(
                             Issue(

--- a/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
+++ b/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
@@ -22,7 +22,7 @@ class CatkinLintToolPlugin(ToolPlugin):
         if "catkin" not in package or not package["catkin"]:
             return []
 
-        flags = []  # type: List[str]
+        flags: List[str] = []
         flags += self.get_user_flags(level)
 
         try:
@@ -47,7 +47,7 @@ class CatkinLintToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(package, output)
+        issues: List[Issue] = self.parse_output(package, output)
         return issues
 
     @classmethod
@@ -83,12 +83,12 @@ class CatkinLintToolPlugin(ToolPlugin):
         """Parse tool output and report issues."""
         lint_re = r"(.+):\s(.+)\((\d+)\):\s(.+):\s(.+)"
         lint2_re = r"(.+):\s(.+):\s(.+)"
-        parse = re.compile(lint_re)  # type: Pattern[str]
-        parse2 = re.compile(lint2_re)  # type: Pattern[str]
+        parse: Pattern[str] = re.compile(lint_re)
+        parse2: Pattern[str] = re.compile(lint2_re)
 
-        issues = []
+        issues: List[Issue] = []
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if match:
                 if self.check_for_exceptions_has_file(match, package):
                     continue
@@ -107,7 +107,7 @@ class CatkinLintToolPlugin(ToolPlugin):
                     )
                 )
             else:
-                match2 = parse2.match(line)  # type: Optional[Match[str]]
+                match2: Optional[Match[str]] = parse2.match(line)
 
                 if match2:
                     norm_path = os.path.normpath(package.path + "/package.xml")

--- a/statick_tool/plugins/tool/cccc_tool_plugin.py
+++ b/statick_tool/plugins/tool/cccc_tool_plugin.py
@@ -62,10 +62,10 @@ class CCCCToolPlugin(ToolPlugin):
 
         for src in package["c_src"]:
             try:
-                subproc_args = [cccc_bin] + [opts] + [src]  # type: List[str]
-                log_output = subprocess.check_output(
+                subproc_args: List[str] = [cccc_bin] + [opts] + [src]
+                log_output: bytes = subprocess.check_output(
                     subproc_args, stderr=subprocess.STDOUT
-                )  # type: bytes
+                )
             except subprocess.CalledProcessError as ex:
                 if ex.returncode == 1:
                     log_output = ex.output
@@ -87,7 +87,7 @@ class CCCCToolPlugin(ToolPlugin):
         with open(".cccc/cccc.xml") as fconfig:
             tool_output = xmltodict.parse(fconfig.read())
 
-        issues = self.parse_output(tool_output, package, config_file)
+        issues: List[Issue] = self.parse_output(tool_output, package, config_file)
         return issues
 
     def parse_output(  # pylint: disable=too-many-branches
@@ -99,7 +99,7 @@ class CCCCToolPlugin(ToolPlugin):
 
         config = self.parse_config(config_file)
 
-        results = {}  # type: Dict[Any, Any]
+        results: Dict[Any, Any] = {}
         for module in output["CCCC_Project"]["structural_summary"]["module"]:
             if "name" not in module or isinstance(module, str):
                 break
@@ -128,7 +128,7 @@ class CCCCToolPlugin(ToolPlugin):
                     metrics[field] = {"value": module[field]["@value"]}
             results[module["name"]] = metrics
 
-        issues = self.find_issues(config, results, package)
+        issues: List[Issue] = self.find_issues(config, results, package)
 
         return issues
 
@@ -142,7 +142,7 @@ class CCCCToolPlugin(ToolPlugin):
 
         `cccc --opt_outfile=cccc.opt`
         """
-        config = {}  # type: Dict[Any, Any]
+        config: Dict[Any, Any] = {}
 
         if config_file is None:
             return config
@@ -164,7 +164,7 @@ class CCCCToolPlugin(ToolPlugin):
         self, config: Dict[Any, Any], results: Dict[Any, Any], package: Package
     ) -> List[Issue]:
         """Identify issues by comparing tool results with tool configuration."""
-        issues = []
+        issues: List[Issue] = []
         dummy = []
 
         for key, val in results.items():

--- a/statick_tool/plugins/tool/clang_format_parser.py
+++ b/statick_tool/plugins/tool/clang_format_parser.py
@@ -29,7 +29,7 @@ class ClangFormatXMLParser:
 
     def parse_xml_output(self, output: str, filename: str) -> List[Dict[Any, Any]]:
         """Parse XML output from the clang-format tool."""
-        report = []  # type: List[Dict[Any, Any]]
+        report: List[Dict[Any, Any]] = []
         xmls = output.split("<?xml version='1.0'?>")[1:]
         for xml in xmls:
             try:
@@ -51,16 +51,16 @@ class ClangFormatXMLParser:
         self, content: str, replacements: List[ElementTree.Element]
     ) -> List[Dict[Any, Any]]:
         """Go through content and generate report of issues discovered."""
-        report = []  # type: List[Dict[Any, Any]]
+        report: List[Dict[Any, Any]] = []
         for replacement in replacements:
             offset = int(replacement.get("offset", 0))
             length = int(replacement.get("length", 0))
             replace_text = replacement.text or ""
-            data = {
+            data: Dict[Any, Any] = {
                 "line_no": 0,
                 "deletion": "",
                 "addition": "",
-            }  # type: Dict[Any, Any]
+            }
             # to-be-replaced snippet
             original = content[offset : offset + length]
             # map global offset to line number and offset in line

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -74,20 +74,20 @@ class ClangFormatToolPlugin(ToolPlugin):
         ):
             clang_format_bin = self.plugin_context.args.clang_format_bin
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "make_targets" in package:
             for target in package["make_targets"]:
                 files += target["src"]
         if "headers" in package:
             files += package["headers"]
 
-        check = self.check_configuration(clang_format_bin)  # type: Optional[bool]
+        check: Optional[bool] = self.check_configuration(clang_format_bin)
         if check is None:
             return None
         if not check:
             return []
 
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         try:
             for src in files:
@@ -136,7 +136,7 @@ class ClangFormatToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output, files)  # type: List[Issue]
+        issues: List[Issue] = self.parse_output(total_output, files)
         return issues
 
     def check_configuration(self, clang_format_bin: str) -> Optional[bool]:
@@ -197,8 +197,8 @@ class ClangFormatToolPlugin(ToolPlugin):
     def parse_output(self, total_output: List[str], files: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         clangformat_re = r"<replacement offset="
-        parse = re.compile(clangformat_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(clangformat_re)
+        issues: List[Issue] = []
 
         if (
             not self.plugin_context
@@ -209,7 +209,7 @@ class ClangFormatToolPlugin(ToolPlugin):
                 filename = lines[0]
                 count = 0
                 for line in lines:
-                    match = parse.match(line)  # type: Optional[Match[str]]
+                    match: Optional[Match[str]] = parse.match(line)
                     if match:
                         count += 1
                 if count > 0:

--- a/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
@@ -56,15 +56,15 @@ class ClangTidyToolPlugin(ToolPlugin):
         if self.plugin_context.args.clang_tidy_bin is not None:
             clang_tidy_bin = self.plugin_context.args.clang_tidy_bin
 
-        flags = [
+        flags: List[str] = [
             "-header-filter=" + package["src_dir"] + "/.*",
             "-p",
             package["bin_dir"] + "/compile_commands.json",
             "-extra-arg=-fopenmp=libomp",
-        ]  # type: List[str]
+        ]
         flags += self.get_user_flags(level)
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "make_targets" in package:
             for target in package["make_targets"]:
                 files += target["src"]
@@ -96,7 +96,7 @@ class ClangTidyToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output)  # type: List[Issue]
+        issues: List[Issue] = self.parse_output(output)
         return issues
 
     @classmethod
@@ -112,12 +112,12 @@ class ClangTidyToolPlugin(ToolPlugin):
     def parse_output(self, output: str) -> List[Issue]:
         """Parse tool output and report issues."""
         clang_tidy_re = r"(.+):(\d+):(\d+):\s(.+):\s(.+)\s\[(.+)\]"
-        parse = re.compile(clang_tidy_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(clang_tidy_re)
+        issues: List[Issue] = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if match and not self.check_for_exceptions(match):
                 if (
                     line[1] != "*"

--- a/statick_tool/plugins/tool/cmakelint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cmakelint_tool_plugin.py
@@ -23,7 +23,7 @@ class CMakelintToolPlugin(ToolPlugin):
             # Package is not cmake!
             return []
 
-        flags = []  # type: List[str]
+        flags: List[str] = []
         flags += self.get_user_flags(level)
 
         output = ""
@@ -52,17 +52,17 @@ class CMakelintToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output)
+        issues: List[Issue] = self.parse_output(output)
         return issues
 
     def parse_output(self, output: str) -> List[Issue]:
         """Parse tool output and report issues."""
         cmakelint_re = r"(.+):(\d+):\s(.+)\s\[(.+)\]"
-        parse = re.compile(cmakelint_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(cmakelint_re)
+        issues: List[Issue] = []
 
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if match:
                 issue_type = match.group(4)
                 if issue_type == "syntax":

--- a/statick_tool/plugins/tool/cppcheck_tool_plugin.py
+++ b/statick_tool/plugins/tool/cppcheck_tool_plugin.py
@@ -39,7 +39,7 @@ class CppcheckToolPlugin(ToolPlugin):
         ) or self.plugin_context is None:
             return []
 
-        flags = [
+        flags: List[str] = [
             "--report-progress",
             "--verbose",
             "--inline-suppr",
@@ -62,8 +62,8 @@ class CppcheckToolPlugin(ToolPlugin):
                 universal_newlines=True,
             )
             ver_re = r"(.+) ([0-9]*\.?[0-9]+)"
-            parse = re.compile(ver_re)  # type: Pattern[str]
-            match = parse.match(output)  # type: Optional[Match[str]]
+            parse: Pattern[str] = re.compile(ver_re)
+            match: Optional[Match[str]] = parse.match(output)
             if match:
                 ver = float(match.group(2))
                 # If specific version is not specified just use the installed version.
@@ -87,8 +87,8 @@ class CppcheckToolPlugin(ToolPlugin):
             logging.warning("%s exception: %s", self.get_name(), ex.output)
             return None
 
-        files = []  # type: List[str]
-        include_dirs = []  # type: List[str]
+        files: List[str] = []
+        include_dirs: List[str] = []
         if "make_targets" in package:
             for target in package["make_targets"]:
                 files += target["src"]
@@ -126,7 +126,7 @@ class CppcheckToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output)
+        issues: List[Issue] = self.parse_output(output)
         return issues
 
     # pylint: enable=too-many-locals, too-many-branches, too-many-return-statements
@@ -142,11 +142,11 @@ class CppcheckToolPlugin(ToolPlugin):
     def parse_output(self, output: str) -> List[Issue]:
         """Parse tool output and report issues."""
         cppcheck_re = r"\[(.+):(\d+)\]:\s\((.+?)\s(.+?)\)\s(.+)"
-        parse = re.compile(cppcheck_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(cppcheck_re)
+        issues: List[Issue] = []
         warnings_mapping = self.load_mapping()
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if (
                 match
                 and line[1] != "*"

--- a/statick_tool/plugins/tool/cpplint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cpplint_tool_plugin.py
@@ -29,11 +29,11 @@ class CpplintToolPlugin(ToolPlugin):
             logging.warning("  cpplint not found!")
             return None
 
-        flags = []  # type: List[str]
+        flags: List[str] = []
         flags += self.get_user_flags(level)
         cpplint = package["cpplint"]
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "make_targets" in package:
             for target in package["make_targets"]:
                 files += target["src"]
@@ -61,7 +61,7 @@ class CpplintToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output)
+        issues: List[Issue] = self.parse_output(output)
         return issues
 
     @classmethod
@@ -87,10 +87,10 @@ class CpplintToolPlugin(ToolPlugin):
     def parse_output(self, output: str) -> List[Issue]:
         """Parse tool output and report issues."""
         lint_re = r"(.+):(\d+):\s(.+)\s\[(.+)\]\s\[(\d+)\]"
-        parse = re.compile(lint_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(lint_re)
+        issues: List[Issue] = []
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if match and not self.check_for_exceptions(match):
                 norm_path = os.path.normpath(match.group(1))
                 issues.append(

--- a/statick_tool/plugins/tool/docformatter_tool_plugin.py
+++ b/statick_tool/plugins/tool/docformatter_tool_plugin.py
@@ -23,11 +23,11 @@ class DocformatterToolPlugin(ToolPlugin):
         if "python_src" not in package:
             return []
 
-        flags = ["-c"]  # type: List[str]
+        flags: List[str] = ["-c"]
         user_flags = self.get_user_flags(level)
         flags += user_flags
         tool_bin = "docformatter"
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         for src in package["python_src"]:
             try:
@@ -58,7 +58,7 @@ class DocformatterToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)  # type: List[Issue]
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     # pylint: enable=too-many-locals, too-many-branches, too-many-return-statements
@@ -67,13 +67,13 @@ class DocformatterToolPlugin(ToolPlugin):
         """Parse tool output and report issues."""
         # Gives relative path to file.
         tool_re = r"(.+)[\\/](.+)"
-        parse = re.compile(tool_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(tool_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             lines = output.splitlines()
             for line in lines:
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     issues.append(
                         Issue(

--- a/statick_tool/plugins/tool/flawfinder_tool_plugin.py
+++ b/statick_tool/plugins/tool/flawfinder_tool_plugin.py
@@ -21,9 +21,9 @@ class FlawfinderToolPlugin(ToolPlugin):
         if "c_src" not in package:
             return []
 
-        flags = ["--quiet", "-D", "--singleline"]
+        flags: List[str] = ["--quiet", "-D", "--singleline"]
         flags += self.get_user_flags(level)
-        total_output = []
+        total_output: List[str] = []
 
         for src in package["c_src"]:
             try:
@@ -49,18 +49,18 @@ class FlawfinderToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         flawfinder_re = r"(.+):(\d+):\s+\[(\d+)\]\s+(.+):\s*(.+)"
-        parse = re.compile(flawfinder_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(flawfinder_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             for line in output.splitlines():
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     issues.append(
                         Issue(

--- a/statick_tool/plugins/tool/isort_tool_plugin.py
+++ b/statick_tool/plugins/tool/isort_tool_plugin.py
@@ -21,11 +21,11 @@ class IsortToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> List[Issue]:
         """Run tool and gather output."""
-        flags = ["--check-only"]
+        flags: List[str] = ["--check-only"]
         user_flags = self.get_user_flags(level)
         flags += user_flags
 
-        total_output = []
+        total_output: List[str] = []
 
         for src in package["python_src"]:
             if not isort.check_file(src):  # type: ignore
@@ -36,12 +36,12 @@ class IsortToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
-        issues = []
+        issues: List[Issue] = []
 
         for output in total_output:
             msg = "Imports are incorrectly sorted and/or formatted."

--- a/statick_tool/plugins/tool/lizard_tool_plugin.py
+++ b/statick_tool/plugins/tool/lizard_tool_plugin.py
@@ -63,21 +63,21 @@ class LizardToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output)
+        issues: List[Issue] = self.parse_output(output)
 
         return issues
 
     def parse_output(self, output: str) -> List[Issue]:
         """Parse tool output and report issues."""
         lizard_re = r"(.+):(\d+):\s(.+):\s(.+)"
-        parse = re.compile(lizard_re)  # type: Pattern[str]
+        parse: Pattern[str] = re.compile(lizard_re)
         matches = []
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if match:
                 matches.append(match.groups())
 
-        issues = []  # type: List[Issue]
+        issues: List[Issue] = []
         for item in matches:
             issue = Issue(
                 item[0], item[1], self.get_name(), item[2], "5", item[3], None

--- a/statick_tool/plugins/tool/make_tool_plugin.py
+++ b/statick_tool/plugins/tool/make_tool_plugin.py
@@ -23,7 +23,7 @@ class MakeToolPlugin(ToolPlugin):
             return []
 
         output = None
-        make_args = ["make", "statick_cmake_target"]
+        make_args: List[str] = ["make", "statick_cmake_target"]
 
         try:
             output = subprocess.check_output(["make", "clean"], universal_newlines=True)
@@ -47,7 +47,7 @@ class MakeToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(package, output)
+        issues: List[Issue] = self.parse_output(package, output)
         return issues
 
     @classmethod
@@ -86,18 +86,18 @@ class MakeToolPlugin(ToolPlugin):
         """Parse tool output and report issues."""
         make_re = r"(.+):(\d+):(\d+):\s(.+):\s(.+)"
         make_warning_re = r".*\[(.+)\].*"
-        parse = re.compile(make_re)  # type: Pattern[str]
-        warning_parse = re.compile(make_warning_re)  # type: Pattern[str]
-        matches = []  # type: Any
+        parse: Pattern[str] = re.compile(make_re)
+        warning_parse: Pattern[str] = re.compile(make_warning_re)
+        matches: Any = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
         for line in output.splitlines():
-            match = parse.match(line)  # type: Optional[Match[str]]
+            match: Optional[Match[str]] = parse.match(line)
             if match and not self.check_for_exceptions(match):
                 matches.append(match.groups())
 
         filtered_matches = self.filter_matches(matches, package)
-        issues = []  # type: List[Issue]
+        issues: List[Issue] = []
         for item in filtered_matches:
             cert_reference = None
             warning_list = warning_parse.match(item[4])

--- a/statick_tool/plugins/tool/mypy_tool_plugin.py
+++ b/statick_tool/plugins/tool/mypy_tool_plugin.py
@@ -23,15 +23,15 @@ class MypyToolPlugin(ToolPlugin):
         if "python_src" not in package:
             return []
 
-        flags = [
+        flags: List[str] = [
             "--show-absolute-path",
             "--show-error-codes",
             "--no-error-summary",
-        ]  # type: List[str]
+        ]
         user_flags = self.get_user_flags(level)
         flags += user_flags
         tool_bin = "mypy"
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         for src in package["python_src"]:
             try:
@@ -60,7 +60,7 @@ class MypyToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)  # type: List[Issue]
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     # pylint: disable=too-many-locals, too-many-branches, too-many-return-statements
@@ -69,15 +69,15 @@ class MypyToolPlugin(ToolPlugin):
         """Parse tool output and report issues."""
         # file:line: severity: msg type
         tool_re = r"(.+):(\d+):\s(.+):\s(.+)\s(.+)"
-        parse = re.compile(tool_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(tool_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             lines = output.splitlines()
             for line in lines:
                 if sys.platform != "win32" and not line.startswith("/"):
                     continue
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     issue_type = match.group(5).strip("[]")
                     issues.append(

--- a/statick_tool/plugins/tool/perlcritic_tool_plugin.py
+++ b/statick_tool/plugins/tool/perlcritic_tool_plugin.py
@@ -2,7 +2,7 @@
 import argparse
 import logging
 import subprocess
-from typing import List, Optional
+from typing import List
 
 from statick_tool.issue import Issue
 from statick_tool.package import Package
@@ -25,7 +25,7 @@ class PerlCriticToolPlugin(ToolPlugin):
             help="perlcritic binary path",
         )
 
-    def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
+    def scan(self, package: Package, level: str) -> List[Issue]:
         """Run tool and gather output."""
         if "perl_src" not in package:
             return []
@@ -39,7 +39,7 @@ class PerlCriticToolPlugin(ToolPlugin):
         flags = ["--nocolor", "--verbose=%f:::%l:::%p:::%m:::%s\n"]
         flags += self.get_user_flags(level)
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "perl_src" in package:
             files += package["perl_src"]
 
@@ -67,13 +67,13 @@ class PerlCriticToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "wt") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(output.splitlines())
+        issues: List[Issue] = self.parse_output(output.splitlines())
 
         return issues
 
     def parse_output(self, output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
-        issues = []
+        issues: List[Issue] = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
         for line in output:

--- a/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
@@ -22,7 +22,7 @@ class PycodestyleToolPlugin(ToolPlugin):
         user_flags = self.get_user_flags(level)
         flags += user_flags
 
-        total_output = []
+        total_output: List[str] = []
 
         tool_bin = "pycodestyle"
         for src in package["python_src"]:
@@ -54,18 +54,18 @@ class PycodestyleToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         tool_re = r"(.+):(\d+):\s\[(.+)\]\s(.+)"
-        parse = re.compile(tool_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(tool_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             for line in output.splitlines():
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     if "," in match.group(3):
                         parts = match.group(3).split(",")

--- a/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
@@ -18,7 +18,7 @@ class PydocstyleToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
-        flags = []  # type: List[str]
+        flags: List[str] = []
         user_flags = self.get_user_flags(level)
         flags += user_flags
         total_output = []
@@ -53,7 +53,7 @@ class PydocstyleToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(  # pylint: disable=too-many-locals
@@ -61,10 +61,10 @@ class PydocstyleToolPlugin(ToolPlugin):
     ) -> List[Issue]:
         """Parse tool output and report issues."""
         tool_re = r"(.+):(\d+)"
-        parse_first = re.compile(tool_re)  # type: Pattern[str]
+        parse_first: Pattern[str] = re.compile(tool_re)
         tool_re_second = r"\s(.+):\s(.+)"
-        parse_second = re.compile(tool_re_second)  # type: Pattern[str]
-        issues = []
+        parse_second: Pattern[str] = re.compile(tool_re_second)
+        issues: List[Issue] = []
         filename = ""
         line_number = "0"
         issue_type = ""
@@ -74,15 +74,13 @@ class PydocstyleToolPlugin(ToolPlugin):
             first_line = True
             for line in output.splitlines():
                 if first_line:
-                    match = parse_first.match(line)  # type: Optional[Match[str]]
+                    match: Optional[Match[str]] = parse_first.match(line)
                     first_line = False
                     if match:
                         filename = match.group(1)
                         line_number = match.group(2)
                 else:
-                    match_second = parse_second.match(
-                        line
-                    )  # type: Optional[Match[str]]
+                    match_second: Optional[Match[str]] = parse_second.match(line)
                     first_line = True
                     if match_second:
                         issue_type = match_second.group(1)

--- a/statick_tool/plugins/tool/pyflakes_tool_plugin.py
+++ b/statick_tool/plugins/tool/pyflakes_tool_plugin.py
@@ -18,10 +18,10 @@ class PyflakesToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
-        flags = []  # type: List[str]
+        flags: List[str] = []
         flags += self.get_user_flags(level)
 
-        total_output = []
+        total_output: List[str] = []
 
         for src in package["python_src"]:
             try:
@@ -52,7 +52,7 @@ class PyflakesToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(  # pylint: disable=too-many-locals
@@ -60,14 +60,14 @@ class PyflakesToolPlugin(ToolPlugin):
     ) -> List[Issue]:
         """Parse tool output and report issues."""
         tool_re_first = r"(.+):(\d+):(\d+):\s(.+)"
-        parse_first = re.compile(tool_re_first)  # type: Pattern[str]
+        parse_first: Pattern[str] = re.compile(tool_re_first)
         tool_re_second = r"(.+):(\d+):( \'.*?\'|'.*?')\s(.+)"
-        parse_second = re.compile(tool_re_second)  # type: Pattern[str]
+        parse_second: Pattern[str] = re.compile(tool_re_second)
         tool_re_third = r"(.+)"
-        parse_third = re.compile(tool_re_third)  # type: Pattern[str]
+        parse_third: Pattern[str] = re.compile(tool_re_third)
         tool_re_fourth = r"(.+):(\d+):(\d+)( \'.*?\'|'.*?')\s(.+)"
-        parse_fourth = re.compile(tool_re_fourth)  # type: Pattern[str]
-        issues = []
+        parse_fourth: Pattern[str] = re.compile(tool_re_fourth)
+        issues: List[Issue] = []
         filename = ""
         line_number = "0"
         issue_type = ""
@@ -78,7 +78,7 @@ class PyflakesToolPlugin(ToolPlugin):
             found_match = False
             for line in output.splitlines():
                 if first_line:
-                    match = parse_first.match(line)  # type: Optional[Match[str]]
+                    match: Optional[Match[str]] = parse_first.match(line)
                     first_line = False
                     if match:
                         found_match = True
@@ -86,25 +86,23 @@ class PyflakesToolPlugin(ToolPlugin):
                         line_number = match.group(2)
                         issue_type = match.group(4)
                     else:
-                        match_second = parse_second.match(
-                            line
-                        )  # type: Optional[Match[str]]
+                        match_second: Optional[Match[str]] = parse_second.match(line)
                         if match_second:
                             found_match = True
                             filename = match_second.group(1)
                             line_number = match_second.group(2)
                             issue_type = match_second.group(4)
                         else:
-                            match_fourth = parse_fourth.match(
+                            match_fourth: Optional[Match[str]] = parse_fourth.match(
                                 line
-                            )  # type: Optional[Match[str]]
+                            )
                             if match_fourth:
                                 found_match = True
                                 filename = match_fourth.group(1)
                                 line_number = match_fourth.group(2)
                                 issue_type = match_fourth.group(5)
                 else:
-                    match_third = parse_third.match(line)  # type: Optional[Match[str]]
+                    match_third: Optional[Match[str]] = parse_third.match(line)
                     first_line = True
                     if match_third:
                         found_match = True

--- a/statick_tool/plugins/tool/pylint_tool_plugin.py
+++ b/statick_tool/plugins/tool/pylint_tool_plugin.py
@@ -18,13 +18,13 @@ class PylintToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
-        flags = [
+        flags: List[str] = [
             "--msg-template='{abspath}:{line}: [{msg_id}({symbol}), {obj}] {msg}'",
             "--reports=no",
         ]
         flags += self.get_user_flags(level)
 
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         for src in package["python_src"]:
             try:
@@ -54,18 +54,18 @@ class PylintToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         pylint_re = r"(.+):(\d+):\s\[(.+)\]\s(.+)"
-        parse = re.compile(pylint_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(pylint_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             for line in output.splitlines():
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     if "," in match.group(3):
                         parts = match.group(3).split(",")

--- a/statick_tool/plugins/tool/shellcheck_tool_plugin.py
+++ b/statick_tool/plugins/tool/shellcheck_tool_plugin.py
@@ -34,15 +34,15 @@ class ShellcheckToolPlugin(ToolPlugin):
         if "shell_src" not in package or not package["shell_src"]:
             return []
 
-        shellcheck_bin = "shellcheck"  # type: str
+        shellcheck_bin: str = "shellcheck"
         if self.plugin_context and self.plugin_context.args.shellcheck_bin is not None:
             shellcheck_bin = self.plugin_context.args.shellcheck_bin
 
         # Get output in JSON format.
-        flags = ["-f", "json"]  # type: List[str]
+        flags: List[str] = ["-f", "json"]
         flags += self.get_user_flags(level)
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "shell_src" in package:
             files += package["shell_src"]
 
@@ -70,12 +70,12 @@ class ShellcheckToolPlugin(ToolPlugin):
             with open(self.get_name() + ".log", "w") as fid:
                 fid.write(output)
 
-        issues = self.parse_output(json.loads(output))
+        issues: List[Issue] = self.parse_output(json.loads(output))
         return issues
 
     def parse_output(self, output: Any) -> List[Issue]:
         """Parse tool output and report issues."""
-        issues = []  # type: List[Issue]
+        issues: List[Issue] = []
         for item in output:
             if (
                 "level" not in item

--- a/statick_tool/plugins/tool/spotbugs_tool_plugin.py
+++ b/statick_tool/plugins/tool/spotbugs_tool_plugin.py
@@ -34,17 +34,17 @@ class SpotbugsToolPlugin(ToolPlugin):
         if self.plugin_context is None:
             return None
 
-        flags = [
+        flags: List[str] = [
             "-Dspotbugs.effort=Max",
             "-Dspotbugs.threshold=Low",
             "-Dspotbugs.xmlOutput=true",
         ]
         flags += self.get_user_flags(level)
 
-        include_file = self.plugin_context.config.get_tool_config(
+        include_file: Optional[str] = self.plugin_context.config.get_tool_config(
             self.get_name(), level, "include"
         )
-        exclude_file = self.plugin_context.config.get_tool_config(
+        exclude_file: Optional[str] = self.plugin_context.config.get_tool_config(
             self.get_name(), level, "exclude"
         )
         if include_file is not None:
@@ -61,8 +61,8 @@ class SpotbugsToolPlugin(ToolPlugin):
                 )
             ]
 
-        issues = []  # type: List[Issue]
-        total_output = ""
+        issues: List[Issue] = []
+        total_output: str = ""
         for pom in package["top_poms"]:
             try:
                 # The spotbugs:spotbugs-maven-plugin split is auto-concatenated
@@ -104,7 +104,7 @@ class SpotbugsToolPlugin(ToolPlugin):
 
     def parse_output(self, output: str) -> Optional[List[Issue]]:
         """Parse tool output and report issues."""
-        issues = []  # type: List[Issue]
+        issues: List[Issue] = []
         # Load the plugin mapping if possible
         warnings_mapping = self.load_mapping()
         try:
@@ -115,7 +115,7 @@ class SpotbugsToolPlugin(ToolPlugin):
                 ex,
                 output,
             )
-            return None
+            return None  # This might be better to return empty issues list here.
         for file_entry in output_xml.findall("file"):
             # Generate the filename
             java_path_string = "{}.java".format(

--- a/statick_tool/plugins/tool/uncrustify_tool_plugin.py
+++ b/statick_tool/plugins/tool/uncrustify_tool_plugin.py
@@ -40,17 +40,17 @@ class UncrustifyToolPlugin(ToolPlugin):
         if self.plugin_context.args.uncrustify_bin is not None:
             uncrustify_bin = self.plugin_context.args.uncrustify_bin
 
-        flags = []  # type: List[str]
+        flags: List[str] = []
         flags += self.get_user_flags(level)
 
-        files = []  # type: List[str]
+        files: List[str] = []
         if "make_targets" in package:
             for target in package["make_targets"]:
                 files += target["src"]
         if "headers" in package:
             files += package["headers"]
 
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         try:
             format_file_name = self.plugin_context.resources.get_file("uncrustify.cfg")
@@ -105,12 +105,12 @@ class UncrustifyToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
-        issues = []
+        issues: List[Issue] = []
         for output in total_output:
             issues.append(
                 Issue(

--- a/statick_tool/plugins/tool/xmllint_tool_plugin.py
+++ b/statick_tool/plugins/tool/xmllint_tool_plugin.py
@@ -18,10 +18,10 @@ class XmllintToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
-        flags = []  # type: List[str]
+        flags: List[str] = []
         flags += self.get_user_flags(level)
 
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         for xml_file in package["xml"]:
             try:
@@ -50,18 +50,18 @@ class XmllintToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         xmllint_re = r"(.+):(\d+):\s(.+)\s:\s(.+)"
-        parse = re.compile(xmllint_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(xmllint_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             for line in output.splitlines():
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     issues.append(
                         Issue(

--- a/statick_tool/plugins/tool/yamllint_tool_plugin.py
+++ b/statick_tool/plugins/tool/yamllint_tool_plugin.py
@@ -18,10 +18,10 @@ class YamllintToolPlugin(ToolPlugin):
 
     def scan(self, package: Package, level: str) -> Optional[List[Issue]]:
         """Run tool and gather output."""
-        flags = ["-f", "parsable"]
+        flags: List[str] = ["-f", "parsable"]
         flags += self.get_user_flags(level)
 
-        total_output = []  # type: List[str]
+        total_output: List[str] = []
 
         for yaml_file in package["yaml"]:
             try:
@@ -51,18 +51,18 @@ class YamllintToolPlugin(ToolPlugin):
                 for output in total_output:
                     fid.write(output)
 
-        issues = self.parse_output(total_output)
+        issues: List[Issue] = self.parse_output(total_output)
         return issues
 
     def parse_output(self, total_output: List[str]) -> List[Issue]:
         """Parse tool output and report issues."""
         yamllint_re = r"(.+):(\d+):(\d+):\s\[(.+)\]\s(.+)\s\((.+)\)"
-        parse = re.compile(yamllint_re)  # type: Pattern[str]
-        issues = []
+        parse: Pattern[str] = re.compile(yamllint_re)
+        issues: List[Issue] = []
 
         for output in total_output:
             for line in output.splitlines():
-                match = parse.match(line)  # type: Optional[Match[str]]
+                match: Optional[Match[str]] = parse.match(line)
                 if match:
                     issue_type = match.group(4)
                     if issue_type == "error":

--- a/statick_tool/resources.py
+++ b/statick_tool/resources.py
@@ -15,7 +15,7 @@ class Resources:
 
     def __init__(self, paths: List[str]) -> None:
         """Initialize resource handling."""
-        self.paths = []  # type: List[str]
+        self.paths: List[str] = []
 
         for path in paths:
             if os.path.exists(path) and os.path.isdir(path):

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -42,26 +42,26 @@ class Statick:
         )
         self.manager.collectPlugins()
 
-        self.discovery_plugins = {}  # type: Dict[str, Any]
+        self.discovery_plugins: Dict[str, Any] = {}
         for plugin_info in self.manager.getPluginsOfCategory("Discovery"):
             self.discovery_plugins[
                 plugin_info.plugin_object.get_name()
             ] = plugin_info.plugin_object
 
-        self.tool_plugins = {}  # type: Dict[str, Any]
+        self.tool_plugins: Dict[str, Any] = {}
         for plugin_info in self.manager.getPluginsOfCategory("Tool"):
             self.tool_plugins[
                 plugin_info.plugin_object.get_name()
             ] = plugin_info.plugin_object
 
-        self.reporting_plugins = {}  # type: Dict[str, Any]
+        self.reporting_plugins: Dict[str, Any] = {}
         for plugin_info in self.manager.getPluginsOfCategory("Reporting"):
             self.reporting_plugins[
                 plugin_info.plugin_object.get_name()
             ] = plugin_info.plugin_object
 
-        self.config = None  # type: Optional[Config]
-        self.exceptions = None  # type: Optional[Exceptions]
+        self.config: Optional[Config] = None
+        self.exceptions: Optional[Exceptions] = None
 
     @staticmethod
     def set_logging_level(args: argparse.Namespace) -> None:
@@ -256,7 +256,7 @@ class Statick:
             return None, False
 
         package = Package(os.path.basename(path), path)
-        level = self.get_level(path, args)  # type: Optional[str]
+        level: Optional[str] = self.get_level(path, args)
         logging.info("level: %s", level)
         if level is None:
             logging.error("Level is not valid.")
@@ -298,7 +298,7 @@ class Statick:
             "Scanning package %s (%s) at level %s", package.name, package.path, level
         )
 
-        issues = {}  # type: Dict[str, List[Issue]]
+        issues: Dict[str, List[Issue]] = {}
 
         ignore_packages = self.get_ignore_packages()
         if package.name in ignore_packages:
@@ -318,7 +318,7 @@ class Statick:
         discovery_plugins = self.config.get_enabled_discovery_plugins(level)
         if not discovery_plugins:
             discovery_plugins = list(self.discovery_plugins.keys())
-        plugins_ran = []  # type: List[Any]
+        plugins_ran: List[Any] = []
         for plugin_name in discovery_plugins:
             if plugin_name not in self.discovery_plugins:
                 logging.error("Can't find specified discovery plugin %s!", plugin_name)
@@ -350,7 +350,7 @@ class Statick:
         enabled_plugins = self.config.get_enabled_tool_plugins(level)
         plugins_to_run = copy.copy(enabled_plugins)
         plugins_ran = []
-        plugin_dependencies = []  # type: List[str]
+        plugin_dependencies: List[str] = []
         while plugins_to_run:
             plugin_name = plugins_to_run[0]
 
@@ -531,7 +531,7 @@ class Statick:
         logging.info("-- overall report --")
 
         success = True
-        issues = {}  # type: Dict[str, List[Issue]]
+        issues: Dict[str, List[Issue]] = {}
         for issue in total_issues:
             if issue is not None:
                 for key, value in list(issue.items()):
@@ -544,7 +544,7 @@ class Statick:
                         if value:
                             success = False
 
-        enabled_reporting_plugins = []  # type: List[str]
+        enabled_reporting_plugins: List[str] = []
         available_reporting_plugins = {}
         for plugin_info in self.manager.getPluginsOfCategory("Reporting"):
             available_reporting_plugins[

--- a/statick_tool/tool_plugin.py
+++ b/statick_tool/tool_plugin.py
@@ -39,11 +39,11 @@ class ToolPlugin(IPlugin):  # type: ignore
 
     def load_mapping(self) -> Dict[str, str]:
         """Load a mapping between warnings and identifiers."""
-        file_name = "plugin_mapping/{}.txt".format(self.get_name())  # type: str
+        file_name: str = "plugin_mapping/{}.txt".format(self.get_name())
         assert self.plugin_context is not None
-        full_path = self.plugin_context.resources.get_file(
+        full_path: Union[Any, str, None] = self.plugin_context.resources.get_file(
             file_name
-        )  # type: Union[Any, str, None]
+        )
         if self.plugin_context.args.mapping_file_suffix is not None:
             # If the user specified a suffix, try to get the suffixed version of the
             # file.
@@ -60,7 +60,7 @@ class ToolPlugin(IPlugin):  # type: ignore
 
         if full_path is None:
             return {}
-        warning_mapping = {}  # type: Dict[str, str]
+        warning_mapping: Dict[str, str] = {}
         with open(full_path, "r") as mapping_file:
             for line in mapping_file.readlines():
                 split_line = line.strip().split(":")
@@ -78,7 +78,7 @@ class ToolPlugin(IPlugin):  # type: ignore
             name = self.get_name()  # pylint: disable=assignment-from-no-return
         assert self.plugin_context is not None
         user_flags = self.plugin_context.config.get_tool_config(name, level, "flags")
-        flags = []  # type: List[str]
+        flags: List[str] = []
         if user_flags:
             # See https://github.com/python/typeshed/issues/1476 for
             # justification to ignore.

--- a/tests/plugins/tool/mypy_tool_plugin/valid_package/wrong_mypy.py
+++ b/tests/plugins/tool/mypy_tool_plugin/valid_package/wrong_mypy.py
@@ -1,1 +1,1 @@
-my_str = "not an int"  # type: int
+my_str: int = "not an int"


### PR DESCRIPTION
I looked for comment style type hints by using the following grep search in `statick_tool`, `tests`, and `examples`.

```sh
grep -rn "# type:" | grep -v ignore
```