### PR TITLE
Workflow trigger 383

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 ---
 name: Statick
 
-on: [pull_request, push, workflow_dispatch]  # NOLINT
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 3 * * MON'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 ---
 name: Statick
 
-on: [pull_request, push]  # NOLINT
+on: [pull_request, push, workflow_dispatch]  # NOLINT
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 ---
 name: Statick
 
-on:
+on: # NOLINT
   pull_request:
   push:
   schedule:


### PR DESCRIPTION
This pull request might be best tested in a private fork.   I couldn't think of a better way .

For two reasons - it's not easy to verify that the build is actually triggered at the scheduled time if not on the default branch of a repo.  

Also the button for manually triggering a workflow only appears on the default branch of a repo.   So to test these capabilities I changed the default branch of my personal fork to the issue branch.    That's not something advisable on a "production" repo like this one since it can break things, like any active PRs.

Attached here a screenshot of where the button to manually trigger a workflow run should appear.  This was on my personal fork, after having changed the default branch from 'main' to the issue branch.


![manual_run](https://user-images.githubusercontent.com/89165446/132567428-1107a393-9c7d-486d-8296-38524db99590.png)
