### PR TITLE
Adjusting docker tag.

### DIFF
--- a/.github/workflows/publish_docker_image.yaml
+++ b/.github/workflows/publish_docker_image.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
I think this will get rid of the 'v' in tag used on the docker image when pushed on release.

For some verification, [see this attempt on my personal repo](https://github.com/gregtkogut/statick/runs/5633557904?check_suite_focus=true#step:5:2642).  The push failed due to authentication failure, but note the tag used was semver with no 'v'.

`#11 pushing ghcr.io/gregtkogut/statick:1.1.1 with docker`

