### PR TITLE
Add support to CMake discovery and cmakelint tool plugins to handle files with .cmake extension.

### DIFF
--- a/statick_tool/discovery_plugin.py
+++ b/statick_tool/discovery_plugin.py
@@ -63,7 +63,7 @@ class DiscoveryPlugin(IPlugin):  # type: ignore
         There are two recommended ways to check it:
         1. When searching for a single string just use the python "in" operator:
 
-            if "search string" in fild_dict["file_cmd_out"]:
+            if "search string" in file_dict["file_cmd_out"]:
 
         2. When searching for multiple different strings, use the `any()` function:
 
@@ -83,6 +83,9 @@ class DiscoveryPlugin(IPlugin):  # type: ignore
                 "Failed to run 'file' command. Returncode = %d", ex.returncode
             )
             logging.warning("Exception output: %s", ex.output)
+            return ""
+        except OSError:
+            logging.warning("OSError on file command for %s", full_path)
             return ""
 
     def set_plugin_context(self, plugin_context: Union[None, PluginContext]) -> None:

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -45,14 +45,16 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
             if file_dict["name"].endswith(".cmake"):
                 package["cmake_src"].append(file_dict["path"])
 
-        package["cmake"] = True
+        package["is_cmake"] = True
         package["make_targets"] = []
         package["headers"] = []
 
         if not os.path.isfile(os.path.join(package.path, "CMakeLists.txt")):
             logging.info("  Package is not cmake.")
-            package["cmake"] = False
+            package["is_cmake"] = False
             return
+
+        package["cmake"] = [os.path.join(package.path, "CMakeLists.txt")]
 
         cmake_template = self.plugin_context.resources.get_file("CMakeLists.txt.in")
         shutil.copyfile(cmake_template, "CMakeLists.txt")  # type: ignore
@@ -125,6 +127,7 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
         self.process_output(output, package)
 
         logging.info("  %d make targets found.", len(package["make_targets"]))
+        logging.info("  %d CMake files found.", len(package["cmake_src"]))
 
     @classmethod
     def process_output(  # pylint: disable=too-many-locals

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -1,4 +1,11 @@
-"""Discovery plugin to find CMake-based projects."""
+"""Discovery plugin to find CMake-based projects.
+
+From the CMake manual, valid CMake files are named `CMakeLists.txt` and `*.cmake`.
+This module will find those files and make them available as part of the package data.
+
+The contents of `CMakeLists.txt` is used to discover make targets and header files
+for the current package. That information is made available as part of the package data.
+"""
 import argparse
 import logging
 import os

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -37,21 +37,19 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
         if self.plugin_context is None:
             return
 
-        cmake_file = os.path.join(package.path, "CMakeLists.txt")
-        cmake_files: List[str] = []
+        package["cmake_src"] = []
 
         self.find_files(package)
 
         for file_dict in package.files.values():
             if file_dict["name"].endswith(".cmake"):
-                cmake_files.append(file_dict["path"])
+                package["cmake_src"].append(file_dict["path"])
 
-        package["cmake_src"] = cmake_files
         package["cmake"] = True
         package["make_targets"] = []
         package["headers"] = []
 
-        if not os.path.isfile(cmake_file):
+        if not os.path.isfile(os.path.join(package.path, "CMakeLists.txt")):
             logging.info("  Package is not cmake.")
             package["cmake"] = False
             return

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -49,7 +49,11 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
         self.find_files(package)
 
         for file_dict in package.files.values():
-            if file_dict["name"].endswith(".cmake"):
+            # Check for all lower-case file name since that is how they are stored.
+            if (
+                file_dict["name"].endswith(".cmake")
+                or file_dict["name"] == "cmakelists.txt"
+            ):
                 package["cmake_src"].append(file_dict["path"])
 
         package["is_cmake"] = True

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -58,13 +58,11 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
             ):
                 package["cmake_src"].append(file_dict["path"])
 
-        package["is_cmake"] = True
         package["make_targets"] = []
         package["headers"] = []
 
         if not os.path.isfile(os.path.join(package.path, "CMakeLists.txt")):
             logging.info("  Package is not cmake.")
-            package["is_cmake"] = False
             return
 
         package["cmake"] = [os.path.join(package.path, "CMakeLists.txt")]

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -38,7 +38,15 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
             return
 
         cmake_file = os.path.join(package.path, "CMakeLists.txt")
+        cmake_files: List[str] = []
 
+        self.find_files(package)
+
+        for file_dict in package.files.values():
+            if file_dict["name"].endswith(".cmake"):
+                cmake_files.append(file_dict["path"])
+
+        package["cmake_src"] = cmake_files
         package["cmake"] = True
         package["make_targets"] = []
         package["headers"] = []

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -3,6 +3,8 @@
 From the CMake manual, valid CMake files are named `CMakeLists.txt` and `*.cmake`.
 This module will find those files and make them available as part of the package data.
 
+https://cmake.org/cmake/help/latest/manual/cmake-language.7.html
+
 The contents of `CMakeLists.txt` is used to discover make targets and header files
 for the current package. That information is made available as part of the package data.
 """

--- a/statick_tool/plugins/tool/cmakelint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cmakelint_tool_plugin.py
@@ -30,7 +30,7 @@ class CMakelintToolPlugin(ToolPlugin):
 
         output = ""
         cmake_files = []
-        if "cmake" in package and package["cmake"]:
+        if "is_cmake" in package and package["is_cmake"]:
             cmake_files.append(os.path.join(package.path, "CMakeLists.txt"))
         if "cmake_src" in package:
             for cmake_file in package["cmake_src"]:

--- a/statick_tool/plugins/tool/cmakelint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cmakelint_tool_plugin.py
@@ -1,6 +1,5 @@
 """Apply cmakelint tool and gather results."""
 import logging
-import os
 import re
 import subprocess
 from typing import List, Match, Optional, Pattern
@@ -19,7 +18,7 @@ class CMakelintToolPlugin(ToolPlugin):
 
     def get_file_types(self) -> List[str]:
         """Return a list of file types the plugin can scan."""
-        return ["cmake"]
+        return ["cmake_src"]
 
     def process_files(
         self, package: Package, level: str, files: List[str], user_flags: List[str]
@@ -30,8 +29,6 @@ class CMakelintToolPlugin(ToolPlugin):
 
         output = ""
         cmake_files = []
-        if "is_cmake" in package and package["is_cmake"]:
-            cmake_files.append(os.path.join(package.path, "CMakeLists.txt"))
         if "cmake_src" in package:
             for cmake_file in package["cmake_src"]:
                 cmake_files.append(cmake_file)

--- a/statick_tool/plugins/tool/cmakelint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cmakelint_tool_plugin.py
@@ -29,10 +29,15 @@ class CMakelintToolPlugin(ToolPlugin):
         flags += user_flags
 
         output = ""
-        cmake_file = os.path.join(package.path, "CMakeLists.txt")
+        cmake_files = []
+        if "cmake" in package and package["cmake"]:
+            cmake_files.append(os.path.join(package.path, "CMakeLists.txt"))
+        if "cmake_src" in package:
+            for cmake_file in package["cmake_src"]:
+                cmake_files.append(cmake_file)
 
         try:
-            subproc_args = ["cmakelint"] + flags + [cmake_file]
+            subproc_args = ["cmakelint"] + flags + cmake_files
             output = subprocess.check_output(
                 subproc_args, stderr=subprocess.STDOUT, universal_newlines=True
             )

--- a/tests/plugins/discovery/cmake_discovery_plugin/cmake_ext_package/CMakeModules/FindCython.cmake
+++ b/tests/plugins/discovery/cmake_discovery_plugin/cmake_ext_package/CMakeModules/FindCython.cmake
@@ -1,0 +1,44 @@
+# Find the Cython compiler.
+#
+# This code sets the following variables:
+#
+#  CYTHON_EXECUTABLE
+#
+# See also UseCython.cmake
+
+#=============================================================================
+# Copyright 2011 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Use the Cython executable that lives next to the Python executable
+# if it is a local installation.
+find_package( PythonInterp )
+if( PYTHONINTERP_FOUND )
+  get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat cython3
+    HINTS ${_python_path}
+    )
+else()
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat cython3
+    )
+endif()
+
+
+include( FindPackageHandleStandardArgs )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )
+
+mark_as_advanced( CYTHON_EXECUTABLE )

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -99,6 +99,24 @@ def test_cmake_discovery_plugin_empty_cmake_flags():
     assert "cmake" in package
 
 
+def test_cmake_discovery_plugin_cmake_file_extension():
+    """Test the CMake discovery plugin finds files with extension cmake."""
+    cmdp = setup_cmake_discovery_plugin()
+    package = Package(
+        "cmake_ext_package",
+        os.path.join(os.path.dirname(__file__), "cmake_ext_package"),
+    )
+    cmdp.scan(package, "level")
+    assert package["cmake_src"] == [
+        os.path.join(
+            os.path.dirname(__file__),
+            "cmake_ext_package",
+            "CMakeModules",
+            "FindCython.cmake",
+        )
+    ]
+
+
 def test_cmake_discovery_plugin_check_output_headers():
     """Test the CMake discovery plugin finds header files."""
     cmdp = setup_cmake_discovery_plugin()
@@ -201,9 +219,9 @@ def test_cmake_discovery_plugin_check_output_cpplint_with_roslint_installed(
 )
 def test_cmake_discovery_plugin_scan_calledprocesserror(mock_subprocess_check_output):
     """
-    Test what happens when a CalledProcessError is raised (usually means yamllint hit an error).
+    Test what happens when a CalledProcessError is raised (usually means CMake hit an error).
 
-    Expected result: issues is None
+    Expected result: no make targets exist
     """
     mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(
         1, "", output="mocked error"
@@ -221,9 +239,9 @@ def test_cmake_discovery_plugin_scan_calledprocesserror(mock_subprocess_check_ou
 )
 def test_cmake_discovery_plugin_scan_oserror(mock_subprocess_check_output):
     """
-    Test what happens when an OSError is raised (usually means yamllint doesn't exist).
+    Test what happens when an OSError is raised (usually means CMake is not available).
 
-    Expected result: issues is None
+    Expected result: no make targets exist
     """
     mock_subprocess_check_output.side_effect = OSError("mocked error")
     package = Package(

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -66,7 +66,7 @@ def test_cmake_discovery_plugin_scan_valid():
     )
     package["cmake_flags"] = "-DCMAKE_PREFIX_PATH=/opt/ros/foxy"
     cmdp.scan(package, "level")
-    assert package["cmake"]
+    assert package["is_cmake"]
 
 
 def test_cmake_discovery_plugin_scan_invalid():
@@ -76,7 +76,7 @@ def test_cmake_discovery_plugin_scan_invalid():
         "invalid_package", os.path.join(os.path.dirname(__file__), "invalid_package")
     )
     cmdp.scan(package, "level")
-    assert not package["cmake"]
+    assert not package["is_cmake"]
 
 
 def test_cmake_discovery_plugin_scan_no_plugin_context():
@@ -86,7 +86,7 @@ def test_cmake_discovery_plugin_scan_no_plugin_context():
         "invalid_package", os.path.join(os.path.dirname(__file__), "invalid_package")
     )
     cmdp.scan(package, "level")
-    assert "cmake" not in package
+    assert "is_cmake" not in package
 
 
 def test_cmake_discovery_plugin_empty_cmake_flags():
@@ -96,7 +96,7 @@ def test_cmake_discovery_plugin_empty_cmake_flags():
         "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
     )
     cmdp.scan(package, "level")
-    assert "cmake" in package
+    assert "is_cmake" in package
 
 
 def test_cmake_discovery_plugin_cmake_file_extension():

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -66,7 +66,7 @@ def test_cmake_discovery_plugin_scan_valid():
     )
     package["cmake_flags"] = "-DCMAKE_PREFIX_PATH=/opt/ros/foxy"
     cmdp.scan(package, "level")
-    assert package["is_cmake"]
+    assert package["cmake_src"]
 
 
 def test_cmake_discovery_plugin_scan_invalid():
@@ -76,7 +76,7 @@ def test_cmake_discovery_plugin_scan_invalid():
         "invalid_package", os.path.join(os.path.dirname(__file__), "invalid_package")
     )
     cmdp.scan(package, "level")
-    assert not package["is_cmake"]
+    assert not package["cmake_src"]
 
 
 def test_cmake_discovery_plugin_scan_no_plugin_context():
@@ -86,7 +86,7 @@ def test_cmake_discovery_plugin_scan_no_plugin_context():
         "invalid_package", os.path.join(os.path.dirname(__file__), "invalid_package")
     )
     cmdp.scan(package, "level")
-    assert "is_cmake" not in package
+    assert "cmake_src" not in package
 
 
 def test_cmake_discovery_plugin_empty_cmake_flags():
@@ -96,7 +96,7 @@ def test_cmake_discovery_plugin_empty_cmake_flags():
         "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
     )
     cmdp.scan(package, "level")
-    assert "is_cmake" in package
+    assert "cmake_src" in package
 
 
 def test_cmake_discovery_plugin_cmake_file_extension():

--- a/tests/plugins/tool/cmakelint_tool_plugin/cmake_ext_package/CMakeLists.txt
+++ b/tests/plugins/tool/cmakelint_tool_plugin/cmake_ext_package/CMakeLists.txt
@@ -1,0 +1,1 @@
+  INVALID_FUNCTION ()

--- a/tests/plugins/tool/cmakelint_tool_plugin/cmake_ext_package/CMakeModules/FindCython.cmake
+++ b/tests/plugins/tool/cmakelint_tool_plugin/cmake_ext_package/CMakeModules/FindCython.cmake
@@ -1,0 +1,44 @@
+# Find the Cython compiler.
+#
+# This code sets the following variables:
+#
+#  CYTHON_EXECUTABLE
+#
+# See also UseCython.cmake
+
+#=============================================================================
+# Copyright 2011 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#=============================================================================
+
+# Use the Cython executable that lives next to the Python executable
+# if it is a local installation.
+find_package( PythonInterp )
+if( PYTHONINTERP_FOUND )
+  get_filename_component( _python_path ${PYTHON_EXECUTABLE} PATH )
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat cython3
+    HINTS ${_python_path}
+    )
+else()
+  find_program( CYTHON_EXECUTABLE
+    NAMES cython cython.bat cython3
+    )
+endif()
+
+
+include( FindPackageHandleStandardArgs )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )
+
+mark_as_advanced( CYTHON_EXECUTABLE )

--- a/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
+++ b/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
@@ -65,7 +65,8 @@ def test_cmakelint_tool_plugin_scan_valid():
     issues = cmltp.scan(package, "level")
     assert not issues
 
-    package["cmake"] = "CMakeLists.txt"
+    package["is_cmake"] = True
+    package["cmake"] = ["CMakeLists.txt"]
     issues = cmltp.scan(package, "level")
     assert len(issues) == 1
 
@@ -79,7 +80,8 @@ def test_cmakelint_tool_plugin_scan_cmake_extension():
     issues = cmltp.scan(package, "level")
     assert not issues
 
-    package["cmake"] = "CMakeLists.txt"
+    package["is_cmake"] = True
+    package["cmake"] = ["CMakeLists.txt"]
     package["cmake_src"] = [
         os.path.join(
             os.path.dirname(__file__),
@@ -124,7 +126,7 @@ def test_cmakelint_tool_plugin_nonexistent_file():
     package = Package(
         "invalid_package", os.path.join(os.path.dirname(__file__), "invalid_package")
     )
-    package["cmake"] = "invalid.txt"
+    package["cmake_src"] = ["invalid.txt"]
     issues = cmltp.scan(package, "level")
     assert not issues
 

--- a/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
+++ b/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
@@ -65,8 +65,10 @@ def test_cmakelint_tool_plugin_scan_valid():
     issues = cmltp.scan(package, "level")
     assert not issues
 
-    package["is_cmake"] = True
-    package["cmake"] = ["CMakeLists.txt"]
+    cmake_file = os.path.join(
+        os.path.dirname(__file__), "valid_package", "CMakeLists.txt"
+    )
+    package["cmake_src"] = [cmake_file]
     issues = cmltp.scan(package, "level")
     assert len(issues) == 1
 
@@ -75,21 +77,24 @@ def test_cmakelint_tool_plugin_scan_cmake_extension():
     """Make sure cmakelint can handle files with extension cmake."""
     cmltp = setup_cmakelint_tool_plugin()
     package = Package(
-        "cmake_ext_package", os.path.join(os.path.dirname(__file__), "cmake_ext_package")
+        "cmake_ext_package",
+        os.path.join(os.path.dirname(__file__), "cmake_ext_package"),
     )
     issues = cmltp.scan(package, "level")
     assert not issues
 
-    package["is_cmake"] = True
-    package["cmake"] = ["CMakeLists.txt"]
-    package["cmake_src"] = [
+    cmake_file = os.path.join(
+        os.path.dirname(__file__), "valid_package", "CMakeLists.txt"
+    )
+    package["cmake_src"] = [cmake_file]
+    package["cmake_src"].append(
         os.path.join(
             os.path.dirname(__file__),
             "cmake_ext_package",
             "CMakeModules",
             "FindCython.cmake",
         )
-    ]
+    )
     issues = cmltp.scan(package, "level")
     assert len(issues) == 6
 
@@ -97,7 +102,9 @@ def test_cmakelint_tool_plugin_scan_cmake_extension():
 def test_cmakelint_tool_plugin_parse_valid():
     """Verify that we can parse the normal output of cmakelint."""
     cmltp = setup_cmakelint_tool_plugin()
-    output = ["valid_package/CMakeLists.txt:1: Extra spaces between 'INVALID_FUNCTION' and its () [whitespace/extra]"]
+    output = [
+        "valid_package/CMakeLists.txt:1: Extra spaces between 'INVALID_FUNCTION' and its () [whitespace/extra]"
+    ]
     issues = cmltp.parse_output(output)
     assert len(issues) == 1
     assert issues[0].filename == "valid_package/CMakeLists.txt"
@@ -145,7 +152,7 @@ def test_cmakelint_tool_plugin_scan_calledprocesserror(mock_subprocess_check_out
     package = Package(
         "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
     )
-    package["cmake"] = [
+    package["cmake_src"] = [
         os.path.join(os.path.dirname(__file__), "valid_package", "CMakeLists.txt")
     ]
     issues = cmltp.scan(package, "level")
@@ -170,7 +177,7 @@ def test_cmakelint_tool_plugin_scan_oserror(mock_subprocess_check_output):
     package = Package(
         "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
     )
-    package["cmake"] = [
+    package["cmake_src"] = [
         os.path.join(os.path.dirname(__file__), "valid_package", "CMakeLists.txt")
     ]
     issues = cmltp.scan(package, "level")

--- a/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
+++ b/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
@@ -70,6 +70,28 @@ def test_cmakelint_tool_plugin_scan_valid():
     assert len(issues) == 1
 
 
+def test_cmakelint_tool_plugin_scan_cmake_extension():
+    """Make sure cmakelint can handle files with extension cmake."""
+    cmltp = setup_cmakelint_tool_plugin()
+    package = Package(
+        "cmake_ext_package", os.path.join(os.path.dirname(__file__), "cmake_ext_package")
+    )
+    issues = cmltp.scan(package, "level")
+    assert not issues
+
+    package["cmake"] = "CMakeLists.txt"
+    package["cmake_src"] = [
+        os.path.join(
+            os.path.dirname(__file__),
+            "cmake_ext_package",
+            "CMakeModules",
+            "FindCython.cmake",
+        )
+    ]
+    issues = cmltp.scan(package, "level")
+    assert len(issues) == 6
+
+
 def test_cmakelint_tool_plugin_parse_valid():
     """Verify that we can parse the normal output of cmakelint."""
     cmltp = setup_cmakelint_tool_plugin()


### PR DESCRIPTION
I tested by installing only statick in a venv with `pip install -e .`. Then I ran against a ROS workspace using a level that had the `make` and `cmakelint` tools configured to run.

I also tested against a repository that had subdirectories with multiple `.cmake` files.  All of the `.cmake` files were discovered, and issues were found on multiple files, indicating that the tool runs as expected against a list of files.

Talk to me if you want more details on specific workspaces and packages I tested against.