### PR TITLE
Pin flake8 to less than version 5.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ setenv = PY_IGNORE_IMPORTMISMATCH = 1
 deps =
     codecov
     deprecated
+    flake8<5
     flake8-pep3101
     pycodestyle
     pydocstyle


### PR DESCRIPTION
The new version 5 has errors when using pytest-flake8.