### PR TITLE
Add blank line before URL in docstring for ROS discovery plugin.

### DIFF
--- a/statick_tool/plugins/discovery/ros_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/ros_discovery_plugin.py
@@ -28,6 +28,7 @@ class RosDiscoveryPlugin(DiscoveryPlugin):
         """Safe way to check for a value in a nested dict.
 
         Copied from:
+
         https://stackoverflow.com/questions/25833613/python-safe-method-to-get-value-of-nested-dictionary
         """
         return reduce(


### PR DESCRIPTION
Fixes warning from new version of docformatter.