### PR TITLE
Add new tool plugin for the ruff tool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ max            |                | 223    | 127    | 64
 
 - Process all source files at once with tools that support passing in a list of files, instead of invoking each tool
   per file. (#470)
+- New tool plugin for the [ruff](https://github.com/charliermarsh/ruff) tool.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ Tool | About
 [pydocstyle][pydocstyle]           | A static analysis tool for checking compliance with Python docstring conventions.
 [pyflakes][pyflakes]               | A simple program which checks Python source files for errors
 [pylint][pylint]                   | It's not just a linter that annoys you!
+[ruff][ruff]                       | An extremely fast Python linter, written in Rust.
 [shellcheck][shellcheck]           | A static analysis tool for shell scripts
 [spotbugs][spotbugs]               | A tool for static analysis to look for bugs in Java code.
 [uncrustify][uncrustify]           | Code beautifier
@@ -873,6 +874,7 @@ His commits were scrubbed from git history upon the initial public release.
 [pydocstyle]: http://www.pydocstyle.org/en/stable/
 [pyflakes]: https://github.com/PyCQA/pyflakes
 [pylint]: https://pylint.org/
+[ruff]: https://github.com/charliermarsh/ruff
 [ros]: https://www.ros.org/
 [shellcheck]: https://github.com/koalaman/shellcheck
 [spotbugs]: https://github.com/spotbugs/spotbugs

--- a/clean.sh
+++ b/clean.sh
@@ -2,4 +2,6 @@
 
 rm -rf build/ dist/ htmlcov/ output-py* .pytest_cache statick.egg-info/ statick_output/* .tox/ ./*.log
 find . -type d -name .mypy_cache -exec rm -rf {} \;
+find . -type d -name .pytest_cache -exec rm -rf {} \;
+find . -type d -name .ruff_cache -exec rm -rf {} \;
 find . -type d -name __pycache__ -exec rm -rf {} \;

--- a/docs/source/statick_tool.plugins.reporting.rst
+++ b/docs/source/statick_tool.plugins.reporting.rst
@@ -12,6 +12,14 @@ Module contents
 Submodules
 ----------
 
+statick_tool.plugins.reporting.code_climate_reporting_plugin module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: statick_tool.plugins.reporting.code_climate_reporting_plugin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 statick_tool.plugins.reporting.do_nothing_reporting_plugin module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/statick_tool.plugins.tool.rst
+++ b/docs/source/statick_tool.plugins.tool.rst
@@ -92,6 +92,14 @@ statick_tool.plugins.tool.docformatter_tool_plugin module
     :undoc-members:
     :show-inheritance:
 
+statick_tool.plugins.tool.do_nothing_tool_plugin module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: statick_tool.plugins.tool.do_nothing_tool_plugin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 statick_tool.plugins.tool.flawfinder_tool_plugin module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -104,6 +112,14 @@ statick_tool.plugins.tool.groovylint_tool_plugin module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: statick_tool.plugins.tool.groovylint_tool_plugin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+statick_tool.plugins.tool.isort_tool_plugin module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: statick_tool.plugins.tool.isort_tool_plugin
     :members:
     :undoc-members:
     :show-inheritance:
@@ -168,6 +184,22 @@ statick_tool.plugins.tool.pylint_tool_plugin module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: statick_tool.plugins.tool.pylint_tool_plugin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+statick_tool.plugins.tool.ruff_tool_plugin module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: statick_tool.plugins.tool.ruff_tool_plugin
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+statick_tool.plugins.tool.shellcheck_tool_plugin module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: statick_tool.plugins.tool.shellcheck_tool_plugin
     :members:
     :undoc-members:
     :show-inheritance:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pydocstyle
 pyflakes
 pylint
 pylint-django<2.0
+ruff
 statick
 statick-md
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "pyflakes",
         "pylint",
         "PyYAML",
+        "ruff",
         "tabulate",
         "xmltodict",
         "yamllint",

--- a/statick_tool/plugins/tool/ruff_tool_plugin.py
+++ b/statick_tool/plugins/tool/ruff_tool_plugin.py
@@ -1,0 +1,78 @@
+"""Apply ruff tool and gather results."""
+import logging
+import re
+import subprocess
+from typing import List, Match, Optional, Pattern
+
+from statick_tool.issue import Issue
+from statick_tool.package import Package
+from statick_tool.tool_plugin import ToolPlugin
+
+
+class RuffToolPlugin(ToolPlugin):
+    """Apply ruff tool and gather results."""
+
+    def get_name(self) -> str:
+        """Get name of tool."""
+        return "ruff"
+
+    def get_file_types(self) -> List[str]:
+        """Return a list of file types the plugin can scan."""
+        return ["python_src"]
+
+    def process_files(
+        self, package: Package, level: str, files: List[str], user_flags: List[str]
+    ) -> Optional[List[str]]:
+        """Run tool and gather output."""
+        flags: List[str] = []
+        flags += user_flags
+
+        total_output: List[str] = []
+
+        try:
+            subproc_args = ["ruff"] + flags + files
+            output = subprocess.check_output(
+                subproc_args, stderr=subprocess.STDOUT, universal_newlines=True
+            )
+
+        except subprocess.CalledProcessError as ex:
+            output = ex.output
+
+        except OSError as ex:
+            logging.warning("Couldn't find ruff executable! (%s)", ex)
+            return None
+
+        total_output.append(output)
+
+        logging.debug("%s", total_output)
+
+        return total_output
+
+    def parse_output(  # pylint: disable=too-many-locals
+        self, total_output: List[str], package: Optional[Package] = None
+    ) -> List[Issue]:
+        """Parse tool output and report issues."""
+        issues: List[Issue] = []
+        # ruff_re = r"(.+):(\d+):(\d+):\s(.+)"
+        ruff_re = r"(.+):(\d+):(\d+):\s(.+)"
+        parse: Pattern[str] = re.compile(ruff_re)
+
+        for output in total_output:  # pylint: disable=too-many-nested-blocks
+            for line in output.splitlines():
+                match: Optional[Match[str]] = parse.match(line)
+                if match:
+                    issue_type = match.group(4).split()[0]
+                    message = match.group(4).split(" ", 1)[1]
+                    issues.append(
+                        Issue(
+                            match.group(1),
+                            match.group(2),
+                            self.get_name(),
+                            issue_type,
+                            "5",
+                            message,
+                            None,
+                        )
+                    )
+
+        return issues

--- a/statick_tool/plugins/tool/ruff_tool_plugin.py
+++ b/statick_tool/plugins/tool/ruff_tool_plugin.py
@@ -48,7 +48,7 @@ class RuffToolPlugin(ToolPlugin):
 
         return total_output
 
-    def parse_output(  # pylint: disable=too-many-locals
+    def parse_output(
         self, total_output: List[str], package: Optional[Package] = None
     ) -> List[Issue]:
         """Parse tool output and report issues."""
@@ -56,7 +56,7 @@ class RuffToolPlugin(ToolPlugin):
         ruff_re = r"(.+):(\d+):(\d+):\s(.+)"
         parse: Pattern[str] = re.compile(ruff_re)
 
-        for output in total_output:  # pylint: disable=too-many-nested-blocks
+        for output in total_output:
             for line in output.splitlines():
                 match: Optional[Match[str]] = parse.match(line)
                 if match:

--- a/statick_tool/plugins/tool/ruff_tool_plugin.py
+++ b/statick_tool/plugins/tool/ruff_tool_plugin.py
@@ -53,7 +53,6 @@ class RuffToolPlugin(ToolPlugin):
     ) -> List[Issue]:
         """Parse tool output and report issues."""
         issues: List[Issue] = []
-        # ruff_re = r"(.+):(\d+):(\d+):\s(.+)"
         ruff_re = r"(.+):(\d+):(\d+):\s(.+)"
         parse: Pattern[str] = re.compile(ruff_re)
 

--- a/statick_tool/plugins/tool/ruff_tool_plugin.yapsy-plugin
+++ b/statick_tool/plugins/tool/ruff_tool_plugin.yapsy-plugin
@@ -1,0 +1,3 @@
+[Core]
+Name = Ruff Tool Plugin
+Module = ruff_tool_plugin

--- a/statick_tool/rsc/config.yaml
+++ b/statick_tool/rsc/config.yaml
@@ -218,6 +218,15 @@ levels:
                        document-start: disable,
                        line-length: disable}}'"
 
+  ruff:
+    discovery:
+      python:
+    reporting:
+      print_to_console:
+    tool:
+      ruff:
+        flags: "--ignore E501"
+
   tex:
     reporting:
       print_to_console:

--- a/tests/plugins/tool/ruff_tool_plugin/test_ruff_tool_plugin.py
+++ b/tests/plugins/tool/ruff_tool_plugin/test_ruff_tool_plugin.py
@@ -1,0 +1,147 @@
+"""Unit tests for the ruff plugin."""
+import argparse
+import os
+import subprocess
+
+import mock
+from yapsy.PluginManager import PluginManager
+
+import statick_tool
+from statick_tool.config import Config
+from statick_tool.package import Package
+from statick_tool.plugin_context import PluginContext
+from statick_tool.plugins.tool.ruff_tool_plugin import RuffToolPlugin
+from statick_tool.resources import Resources
+from statick_tool.tool_plugin import ToolPlugin
+
+
+def setup_ruff_tool_plugin():
+    """Initialize and return a ruff plugin."""
+    arg_parser = argparse.ArgumentParser()
+
+    resources = Resources(
+        [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
+    )
+    config = Config(resources.get_file("config.yaml"))
+    plugin_context = PluginContext(arg_parser.parse_args([]), resources, config)
+    plugin_context.args.output_directory = os.path.dirname(__file__)
+    rtp = RuffToolPlugin()
+    rtp.set_plugin_context(plugin_context)
+    return rtp
+
+
+def test_ruff_tool_plugin_found():
+    """Test that the plugin manager can find the ruff plugin."""
+    manager = PluginManager()
+    # Get the path to statick_tool/__init__.py, get the directory part, and
+    # add 'plugins' to that to get the standard plugins dir
+    manager.setPluginPlaces(
+        [os.path.join(os.path.dirname(statick_tool.__file__), "plugins")]
+    )
+    manager.setCategoriesFilter(
+        {
+            "Tool": ToolPlugin,
+        }
+    )
+    manager.collectPlugins()
+    # Verify that a plugin's get_name() function returns "ruff"
+    assert any(
+        plugin_info.plugin_object.get_name() == "ruff"
+        for plugin_info in manager.getPluginsOfCategory("Tool")
+    )
+    # While we're at it, verify that a plugin is named ruff Tool Plugin
+    assert any(
+        plugin_info.name == "Ruff Tool Plugin"
+        for plugin_info in manager.getPluginsOfCategory("Tool")
+    )
+
+
+def test_ruff_tool_plugin_scan_valid():
+    """Integration test: Make sure the ruff output hasn't changed."""
+    rtp = setup_ruff_tool_plugin()
+    package = Package(
+        "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
+    )
+    package["python_src"] = [
+        os.path.join(os.path.dirname(__file__), "valid_package", "ruff_test.py")
+    ]
+    issues = rtp.scan(package, "level")
+    assert len(issues) == 1
+
+
+def test_ruff_tool_plugin_parse_valid():
+    """Verify that we can parse the normal output of ruff."""
+    rtp = setup_ruff_tool_plugin()
+    output = "some_file.py:644:89: E501 Line too long (96 > 88 characters)"
+    issues = rtp.parse_output([output])
+    assert len(issues) == 1
+    assert issues[0].filename == "some_file.py"
+    assert issues[0].line_number == "644"
+    assert issues[0].tool == "ruff"
+    assert issues[0].issue_type == "E501"
+    assert issues[0].severity == "5"
+    assert issues[0].message == "Line too long (96 > 88 characters)"
+
+    output = "a_file.py:21:1: E402 Module level import not at top of file"
+    issues = rtp.parse_output([output])
+    assert len(issues) == 1
+    assert issues[0].filename == "a_file.py"
+    assert issues[0].line_number == "21"
+    assert issues[0].tool == "ruff"
+    assert issues[0].issue_type == "E402"
+    assert issues[0].severity == "5"
+    assert issues[0].message == "Module level import not at top of file"
+
+
+def test_ruff_tool_plugin_parse_invalid():
+    """Verify that we can parse the normal output of ruff."""
+    rtp = setup_ruff_tool_plugin()
+    output = "invalid text"
+    issues = rtp.parse_output([output])
+    assert not issues
+
+
+@mock.patch("statick_tool.plugins.tool.ruff_tool_plugin.subprocess.check_output")
+def test_ruff_tool_plugin_scan_calledprocesserror(mock_subprocess_check_output):
+    """
+    Test what happens when a CalledProcessError is raised (usually means ruff hit an error).
+
+    Expected result: issues is None
+    """
+    mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(
+        0, "", output="mocked error"
+    )
+    rtp = setup_ruff_tool_plugin()
+    package = Package(
+        "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
+    )
+    package["python_src"] = [
+        os.path.join(os.path.dirname(__file__), "valid_package", "ruff_test.py")
+    ]
+    issues = rtp.scan(package, "level")
+    assert not issues
+
+    mock_subprocess_check_output.side_effect = subprocess.CalledProcessError(
+        32, "", output="mocked error"
+    )
+    issues = rtp.scan(package, "level")
+    assert not issues
+
+
+@mock.patch("statick_tool.plugins.tool.ruff_tool_plugin.subprocess.check_output")
+def test_ruff_tool_plugin_scan_oserror(mock_subprocess_check_output):
+    """
+    Test what happens when an OSError is raised (usually means ruff doesn't exist).
+
+    Expected result: issues is None
+    """
+    mock_subprocess_check_output.side_effect = OSError("mocked error")
+    rtp = setup_ruff_tool_plugin()
+    package = Package(
+        "valid_package", os.path.join(os.path.dirname(__file__), "valid_package")
+    )
+    package["python_src"] = [
+        os.path.join(os.path.dirname(__file__), "valid_package", "ruff_test.py")
+    ]
+    issues = rtp.scan(package, "level")
+    assert issues is None

--- a/tests/plugins/tool/ruff_tool_plugin/valid_package/ruff_test.py
+++ b/tests/plugins/tool/ruff_tool_plugin/valid_package/ruff_test.py
@@ -1,0 +1,6 @@
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json  # NOQA
+
+some_long_variable = "make this string go past the allowed length of 88 characters by adding ridiculous redundancy"


### PR DESCRIPTION
Includes new `ruff` level to do only Python discovery and run `ruff`
tool. Ignores line-too-long warnings since those are better dealt with
by the `black` tool.