### PR TITLE
Remove codecov package from tox configuration.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,6 @@ changedir = {toxinidir}/output-{envname}
 passenv = CI
 setenv = PY_IGNORE_IMPORTMISMATCH = 1
 deps =
-    codecov
     deprecated
     flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
     flake8-pep3101


### PR DESCRIPTION
The package has been deprecated:
https://github.com/codecov/codecov-python

Discussion at:
https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259