### PR TITLE
Have ruff example unit test file generate an error.

### DIFF
--- a/tests/plugins/tool/ruff_tool_plugin/valid_package/ruff_test.py
+++ b/tests/plugins/tool/ruff_tool_plugin/valid_package/ruff_test.py
@@ -3,4 +3,8 @@ try:
 except ImportError:
     from django.utils import simplejson as json  # NOQA
 
+# Need to create an unused import to generate a ruff error.
+import os
+
+# Line too long does not trigger going from ruff v0.0.278 to v0.1.1.
 some_long_variable = "make this string go past the allowed length of 88 characters by adding ridiculous redundancy"

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,7 @@ deps =
     pytest-isort
     .[test]
 commands =
-    pydocstyle ../statick_tool/
-    pycodestyle --ignore=E203,E501,W503 ../statick_tool/
-    pytest --flake8 --isort \
+    pytest \
         --cov={toxinidir}/statick_tool \
         --cov-report term-missing \
         --doctest-modules \


### PR DESCRIPTION
- Line too long error not reported when upgrading ruff tool from 0.0.278 to 0.1.1.
- Not running pycodestyle, pydocstyle, isort, or flake8 during tox run. Those tools are run in other parts of the Statick testing pipeline.