### PR TITLE
Updates for new tool versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 """Setup."""
 
-
 from setuptools import setup  # NOLINT
 
 import statick_tool

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ with open("README.md", encoding="utf8") as f:
 
 TEST_DEPS = [
     "backports.tempfile",
+    "lark",
     "pylint-django",
     "pytest",
     "mock",

--- a/statick_tool/args.py
+++ b/statick_tool/args.py
@@ -2,6 +2,7 @@
 
 Enable usage of user-paths argument before parsing other arguments.
 """
+
 import argparse
 import logging
 import os

--- a/statick_tool/config.py
+++ b/statick_tool/config.py
@@ -2,6 +2,7 @@
 
 Sets what flags are used for each plugin at those levels.
 """
+
 import os
 from typing import Any, List, Optional, Union
 

--- a/statick_tool/discovery_plugin.py
+++ b/statick_tool/discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discovery plugin."""
+
 import logging
 import os
 import subprocess

--- a/statick_tool/exceptions.py
+++ b/statick_tool/exceptions.py
@@ -8,6 +8,7 @@ filename matching for the exception it is required that the reported issue conta
 absolute path to the file containing the issue to be ignored. The path for the issue is
 set in the tool plugin that generates the issues.
 """
+
 import fnmatch
 import logging
 import os

--- a/statick_tool/plugins/discovery/c_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/c_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover C files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional

--- a/statick_tool/plugins/discovery/cmake_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/cmake_discovery_plugin.py
@@ -9,6 +9,7 @@ https://cmake.org/cmake/help/latest/manual/cmake-language.7.html
 The contents of `CMakeLists.txt` is used to discover make targets and header files
 for the current package. That information is made available as part of the package data.
 """
+
 import argparse
 import logging
 import os
@@ -172,9 +173,11 @@ class CMakeDiscoveryPlugin(DiscoveryPlugin):
                     if not qt_p.match(src)
                 ]
                 src = [
-                    src
-                    if os.path.isabs(src)  # noqa F812
-                    else os.path.join(src_dir, src)
+                    (
+                        src
+                        if os.path.isabs(src)  # noqa F812
+                        else os.path.join(src_dir, src)
+                    )
                     for src in src
                 ]  # NOLINT  # noqa F812
 

--- a/statick_tool/plugins/discovery/java_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/java_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover Java files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional

--- a/statick_tool/plugins/discovery/maven_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/maven_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover Maven POM files to analyze."""
+
 import fnmatch
 import logging
 import os

--- a/statick_tool/plugins/discovery/perl_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/perl_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover Perl files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional

--- a/statick_tool/plugins/discovery/python_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/python_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover python files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional

--- a/statick_tool/plugins/discovery/ros_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/ros_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discovery plugin to find ROS packages."""
+
 import logging
 import os
 from functools import reduce
@@ -60,9 +61,9 @@ class RosDiscoveryPlugin(DiscoveryPlugin):
                 if path is not None:
                     for item in path.split(":"):
                         if distro is not None and distro in item:
-                            package[
-                                "cmake_flags"
-                            ] = "-DCMAKE_PREFIX_PATH=" + item.rstrip("/bin")
+                            package["cmake_flags"] = (
+                                "-DCMAKE_PREFIX_PATH=" + item.rstrip("/bin")
+                            )
                 package["is_ros2"] = True
         elif os.path.isfile(package_file) and ros_version is not None:
             with open(package_file, encoding="utf8") as fconfig:

--- a/statick_tool/plugins/discovery/shell_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/shell_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover shell files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional

--- a/statick_tool/plugins/discovery/xml_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/xml_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover XML files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional, Tuple

--- a/statick_tool/plugins/discovery/yaml_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/yaml_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Discover YAML files to analyze."""
+
 import logging
 from collections import OrderedDict
 from typing import List, Optional

--- a/statick_tool/plugins/reporting/code_climate_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/code_climate_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Prints the Statick reports out to the terminal or file in Code Climate JSON."""
+
 import hashlib
 import json
 import logging

--- a/statick_tool/plugins/reporting/do_nothing_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/do_nothing_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Do nothing to have a default reporting plugin with no side effects."""
+
 from typing import Dict, List, Optional, Tuple
 
 from statick_tool.issue import Issue

--- a/statick_tool/plugins/reporting/json_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/json_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Prints the Statick reports out to the terminal or file in JSON format."""
+
 import json
 import logging
 import os

--- a/statick_tool/plugins/reporting/print_to_console_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/print_to_console_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Write issue reports to the console."""
+
 from collections import OrderedDict
 from typing import Dict, List, Optional, Tuple
 

--- a/statick_tool/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Write Statick results to Jenkins Warnings-NG plugin json-log compatible output."""
+
 import json
 import logging
 import os

--- a/statick_tool/plugins/tool/bandit_tool_plugin.py
+++ b/statick_tool/plugins/tool/bandit_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply bandit tool and gather results."""
+
 import argparse
 import csv
 import logging

--- a/statick_tool/plugins/tool/black_tool_plugin.py
+++ b/statick_tool/plugins/tool/black_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply black tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
+++ b/statick_tool/plugins/tool/catkin_lint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply catkin_lint tool and gather results."""
+
 import logging
 import os
 import re

--- a/statick_tool/plugins/tool/cccc_tool_plugin.py
+++ b/statick_tool/plugins/tool/cccc_tool_plugin.py
@@ -7,6 +7,7 @@ find . -name \*.h -print -o -name \*.cpp -print | xargs cccc
 That will generate several reports, including HTML. The results can be viewd in a web
 browser.
 """
+
 import argparse
 import csv
 import logging

--- a/statick_tool/plugins/tool/clang_format_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_format_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply clang-format tool and gather results."""
+
 import argparse
 import difflib
 import logging

--- a/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
+++ b/statick_tool/plugins/tool/clang_tidy_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply clang-tidy tool and gather results."""
+
 import argparse
 import logging
 import re

--- a/statick_tool/plugins/tool/cmakelint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cmakelint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply cmakelint tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/cppcheck_tool_plugin.py
+++ b/statick_tool/plugins/tool/cppcheck_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply cppcheck tool and gather results."""
+
 import argparse
 import logging
 import os

--- a/statick_tool/plugins/tool/cpplint_tool_plugin.py
+++ b/statick_tool/plugins/tool/cpplint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply Cpplint tool and gather results."""
+
 import logging
 import os
 import re

--- a/statick_tool/plugins/tool/do_nothing_tool_plugin.py
+++ b/statick_tool/plugins/tool/do_nothing_tool_plugin.py
@@ -1,4 +1,5 @@
 """Do nothing, this is primarily useful for testing purposes."""
+
 from typing import List, Optional
 
 from statick_tool.issue import Issue

--- a/statick_tool/plugins/tool/docformatter_tool_plugin.py
+++ b/statick_tool/plugins/tool/docformatter_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply docformatter tool and gather results."""
+
 import logging
 import os
 import re

--- a/statick_tool/plugins/tool/flawfinder_tool_plugin.py
+++ b/statick_tool/plugins/tool/flawfinder_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply flawfinder tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/groovylint_tool_plugin.py
+++ b/statick_tool/plugins/tool/groovylint_tool_plugin.py
@@ -21,7 +21,6 @@ class GroovyLintToolPlugin(ToolPlugin):
         """Return a list of file types the plugin can scan."""
         return ["groovy_src"]
 
-    # pylint: disable=too-many-locals
     def process_files(
         self, package: Package, level: str, files: List[str], user_flags: List[str]
     ) -> Optional[List[str]]:
@@ -47,36 +46,33 @@ class GroovyLintToolPlugin(ToolPlugin):
         flags += user_flags
 
         total_output: List[str] = []
-        for src in files:
-            try:
-                exe = [tool_bin] + flags + ["-f", src]
-                output = subprocess.check_output(
-                    exe,
-                    stderr=subprocess.STDOUT,
-                    universal_newlines=True,
-                    cwd=package.path,
+        try:
+            exe = [tool_bin] + flags + files
+            output = subprocess.check_output(
+                exe,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                cwd=package.path,
+            )
+            total_output.append(output)
+        except subprocess.CalledProcessError as ex:
+            # npm-groovy-lint returns 1 on some errors but still has valid output
+            if ex.returncode == 1:
+                total_output.append(ex.output)
+            else:
+                logging.warning(
+                    "%s failed! Returncode = %d", tool_bin, ex.returncode
                 )
-                total_output.append(output)
-            except subprocess.CalledProcessError as ex:
-                # npm-groovy-lint returns 1 on some errors but still has valid output
-                if ex.returncode == 1:
-                    total_output.append(ex.output)
-                else:
-                    logging.warning(
-                        "%s failed! Returncode = %d", tool_bin, ex.returncode
-                    )
-                    logging.warning("%s exception: %s", self.get_name(), ex.output)
-                    return None
-
-            except OSError as ex:
-                logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+                logging.warning("%s exception: %s", self.get_name(), ex.output)
                 return None
 
-        for output in total_output:
-            logging.debug("%s", output)
-        return total_output
+        except OSError as ex:
+            logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+            return None
 
-    # pylint: enable=too-many-locals
+        logging.debug("%s", total_output)
+
+        return total_output
 
     def parse_output(
         self, total_output: List[str], package: Optional[Package] = None
@@ -84,39 +80,43 @@ class GroovyLintToolPlugin(ToolPlugin):
         """Parse tool output and report issues."""
         issues: List[Issue] = []
 
-        # pylint: disable=too-many-nested-blocks
-        for output in total_output:
-            lines = output.split("\n")
-            for line in lines:
+        summary = {}
+        for line in total_output[0].split("\n"):
+            try:
+                err_dict = json.loads(line)
                 try:
-                    err_dict = json.loads(line)
-                    if "files" in err_dict:
-                        all_files = err_dict["files"]
-                        for file_name in all_files:
-                            file_errs = all_files[file_name]
-                            if "errors" in file_errs:
-                                for issue in file_errs["errors"]:
-                                    severity_str = issue["severity"]
-                                    severity = "3"
-                                    if severity_str == "info":
-                                        severity = "1"
-                                    elif severity_str == "warning":
-                                        severity = "3"
-                                    elif severity_str == "error":
-                                        severity = "5"
-                                    issues.append(
-                                        Issue(
-                                            file_name,
-                                            str(issue["line"]),
-                                            self.get_name(),
-                                            issue["rule"],
-                                            severity,
-                                            issue["msg"],
-                                            None,
-                                        )
-                                    )
+                    summary = err_dict
+                except (AttributeError, TypeError):
+                    continue
+                else:
+                    continue
+            except ValueError as ex:
+                logging.warning("ValueError: %s", ex)
 
-                except ValueError as ex:
-                    logging.warning("ValueError: %s", ex)
-        # pylint: enable=too-many-nested-blocks
+        if "files" in summary:
+            all_files = summary["files"]
+            for file_name in all_files:
+                file_errs = all_files[file_name]
+                if "errors" in file_errs:
+                    for issue in file_errs["errors"]:
+                        severity_str = issue["severity"]
+                        severity = "3"
+                        if severity_str == "info":
+                            severity = "1"
+                        elif severity_str == "warning":
+                            severity = "3"
+                        elif severity_str == "error":
+                            severity = "5"
+                        issues.append(
+                            Issue(
+                                file_name,
+                                str(issue["line"]),
+                                self.get_name(),
+                                issue["rule"],
+                                severity,
+                                issue["msg"],
+                                None,
+                            )
+                        )
+
         return issues

--- a/statick_tool/plugins/tool/groovylint_tool_plugin.py
+++ b/statick_tool/plugins/tool/groovylint_tool_plugin.py
@@ -84,12 +84,7 @@ class GroovyLintToolPlugin(ToolPlugin):
         for line in total_output[0].split("\n"):
             try:
                 err_dict = json.loads(line)
-                try:
-                    summary = err_dict
-                except (AttributeError, TypeError):
-                    continue
-                else:
-                    continue
+                summary = err_dict
             except ValueError as ex:
                 logging.warning("ValueError: %s", ex)
 

--- a/statick_tool/plugins/tool/groovylint_tool_plugin.py
+++ b/statick_tool/plugins/tool/groovylint_tool_plugin.py
@@ -60,9 +60,7 @@ class GroovyLintToolPlugin(ToolPlugin):
             if ex.returncode == 1:
                 total_output.append(ex.output)
             else:
-                logging.warning(
-                    "%s failed! Returncode = %d", tool_bin, ex.returncode
-                )
+                logging.warning("%s failed! Returncode = %d", tool_bin, ex.returncode)
                 logging.warning("%s exception: %s", self.get_name(), ex.output)
                 return None
 

--- a/statick_tool/plugins/tool/isort_tool_plugin.py
+++ b/statick_tool/plugins/tool/isort_tool_plugin.py
@@ -3,6 +3,7 @@
 The isort tool will only find if a file has issues with imports. To automatically fix
 the issues you can run `isort <file>`.
 """
+
 import logging
 import subprocess
 from typing import List, Optional

--- a/statick_tool/plugins/tool/lizard_tool_plugin.py
+++ b/statick_tool/plugins/tool/lizard_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply lizard tool and gather results."""
+
 import io
 import logging
 import re

--- a/statick_tool/plugins/tool/make_tool_plugin.py
+++ b/statick_tool/plugins/tool/make_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply make tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/mypy_tool_plugin.py
+++ b/statick_tool/plugins/tool/mypy_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply mypy tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/perlcritic_tool_plugin.py
+++ b/statick_tool/plugins/tool/perlcritic_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply Perl::Critic tool and gather results."""
+
 import argparse
 import logging
 import subprocess

--- a/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pycodestyle_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply pycodestyle tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
+++ b/statick_tool/plugins/tool/pydocstyle_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply pydocstyle tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/pyflakes_tool_plugin.py
+++ b/statick_tool/plugins/tool/pyflakes_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply pyflakes tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/pylint_tool_plugin.py
+++ b/statick_tool/plugins/tool/pylint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply pylint tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/ruff_tool_plugin.py
+++ b/statick_tool/plugins/tool/ruff_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply ruff tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/shellcheck_tool_plugin.py
+++ b/statick_tool/plugins/tool/shellcheck_tool_plugin.py
@@ -2,6 +2,7 @@
 
 The output from the tool is collected in JSON format to facilitate parsing.
 """
+
 import argparse
 import json
 import logging

--- a/statick_tool/plugins/tool/spotbugs_tool_plugin.py
+++ b/statick_tool/plugins/tool/spotbugs_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply spotbugs tool and gather results."""
+
 import logging
 import os
 import subprocess

--- a/statick_tool/plugins/tool/uncrustify_tool_plugin.py
+++ b/statick_tool/plugins/tool/uncrustify_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply uncrustify tool and gather results."""
+
 import argparse
 import difflib
 import logging

--- a/statick_tool/plugins/tool/xmllint_tool_plugin.py
+++ b/statick_tool/plugins/tool/xmllint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply xmllint tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/plugins/tool/yamllint_tool_plugin.py
+++ b/statick_tool/plugins/tool/yamllint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Apply yamllint tool and gather results."""
+
 import logging
 import re
 import subprocess

--- a/statick_tool/reporting_plugin.py
+++ b/statick_tool/reporting_plugin.py
@@ -1,4 +1,5 @@
 """Result reporting plugin."""
+
 import argparse
 import logging
 from typing import Any, Dict, List, Optional, Tuple, Union

--- a/statick_tool/resources.py
+++ b/statick_tool/resources.py
@@ -2,6 +2,7 @@
 
 Handles chaining user directories and the default statick resource directory.
 """
+
 import logging
 import os
 from typing import List, Optional

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -1,4 +1,5 @@
 """Code analysis front-end."""
+
 import argparse
 import copy
 import io
@@ -47,21 +48,21 @@ class Statick:  # pylint: disable=too-many-instance-attributes
 
         self.discovery_plugins: Dict[str, Any] = {}
         for plugin_info in self.manager.getPluginsOfCategory("Discovery"):
-            self.discovery_plugins[
-                plugin_info.plugin_object.get_name()
-            ] = plugin_info.plugin_object
+            self.discovery_plugins[plugin_info.plugin_object.get_name()] = (
+                plugin_info.plugin_object
+            )
 
         self.tool_plugins: Dict[str, Any] = {}
         for plugin_info in self.manager.getPluginsOfCategory("Tool"):
-            self.tool_plugins[
-                plugin_info.plugin_object.get_name()
-            ] = plugin_info.plugin_object
+            self.tool_plugins[plugin_info.plugin_object.get_name()] = (
+                plugin_info.plugin_object
+            )
 
         self.reporting_plugins: Dict[str, Any] = {}
         for plugin_info in self.manager.getPluginsOfCategory("Reporting"):
-            self.reporting_plugins[
-                plugin_info.plugin_object.get_name()
-            ] = plugin_info.plugin_object
+            self.reporting_plugins[plugin_info.plugin_object.get_name()] = (
+                plugin_info.plugin_object
+            )
 
         self.config: Optional[Config] = None
         self.exceptions: Optional[Exceptions] = None

--- a/statick_tool/tool_plugin.py
+++ b/statick_tool/tool_plugin.py
@@ -1,4 +1,5 @@
 """Tool plugin."""
+
 import argparse
 import logging
 import os

--- a/tests/args/test_args.py
+++ b/tests/args/test_args.py
@@ -1,4 +1,5 @@
 """Unit tests for the Args module."""
+
 import os
 
 from statick_tool.args import Args

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,4 +1,5 @@
 """Unit tests for the Config module."""
+
 import os
 
 import mock

--- a/tests/discovery/test_discovery_plugin.py
+++ b/tests/discovery/test_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Tests for statick_tool.discovery_plugin."""
+
 import contextlib
 import os
 import subprocess

--- a/tests/exceptions/test_exceptions.py
+++ b/tests/exceptions/test_exceptions.py
@@ -1,4 +1,5 @@
 """Unit tests for the Exceptions module."""
+
 import os
 import tempfile
 

--- a/tests/plugins/discovery/c_discovery_plugin/test_c_discovery_plugin.py
+++ b/tests/plugins/discovery/c_discovery_plugin/test_c_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the C discovery plugin."""
+
 import contextlib
 import os
 

--- a/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
+++ b/tests/plugins/discovery/cmake_discovery_plugin/test_cmake_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the CMake discovery plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/discovery/java_discovery_plugin/test_java_discovery_plugin.py
+++ b/tests/plugins/discovery/java_discovery_plugin/test_java_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Java discovery plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/discovery/maven_discovery_plugin/test_maven_discovery_plugin.py
+++ b/tests/plugins/discovery/maven_discovery_plugin/test_maven_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Maven discovery plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/discovery/perl_discovery_plugin/test_perl_discovery_plugin.py
+++ b/tests/plugins/discovery/perl_discovery_plugin/test_perl_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Perl discovery plugin."""
+
 import contextlib
 import os
 

--- a/tests/plugins/discovery/python_discovery_plugin/test_python_discovery_plugin.py
+++ b/tests/plugins/discovery/python_discovery_plugin/test_python_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Python discovery plugin."""
+
 import contextlib
 import os
 

--- a/tests/plugins/discovery/ros_discovery_plugin/test_ros_discovery_plugin.py
+++ b/tests/plugins/discovery/ros_discovery_plugin/test_ros_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the ROS discovery plugin."""
+
 import contextlib
 import os
 

--- a/tests/plugins/discovery/shell_discovery_plugin/test_shell_discovery_plugin.py
+++ b/tests/plugins/discovery/shell_discovery_plugin/test_shell_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Shell discovery plugin."""
+
 import contextlib
 import os
 

--- a/tests/plugins/discovery/xml_discovery_plugin/test_xml_discovery_plugin.py
+++ b/tests/plugins/discovery/xml_discovery_plugin/test_xml_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the XML discovery plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/discovery/yaml_discovery_plugin/test_yaml_discovery_plugin.py
+++ b/tests/plugins/discovery/yaml_discovery_plugin/test_yaml_discovery_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the YAML discovery plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/reporting/code_climate_reporting_plugin/test_code_climate_reporting_plugin.py
+++ b/tests/plugins/reporting/code_climate_reporting_plugin/test_code_climate_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the JSON reporting plugin."""
+
 import argparse
 import json
 import os

--- a/tests/plugins/reporting/do_nothing_reporting_plugin/test_do_nothing_reporting_plugin.py
+++ b/tests/plugins/reporting/do_nothing_reporting_plugin/test_do_nothing_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the do nothing reporting plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/reporting/json_reporting_plugin/test_json_reporting_plugin.py
+++ b/tests/plugins/reporting/json_reporting_plugin/test_json_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the JSON reporting plugin."""
+
 import argparse
 import os
 

--- a/tests/plugins/reporting/print_to_console_reporting_plugin/test_print_to_console_reporting_plugin.py
+++ b/tests/plugins/reporting/print_to_console_reporting_plugin/test_print_to_console_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the console reporting plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin/test_write_jenkins_warnings_ng_reporting_plugin.py
+++ b/tests/plugins/reporting/write_jenkins_warnings_ng_reporting_plugin/test_write_jenkins_warnings_ng_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the file writing reporting plugin."""
+
 import argparse
 import json
 import os

--- a/tests/plugins/tool/bandit_tool_plugin/test_bandit_tool_plugin.py
+++ b/tests/plugins/tool/bandit_tool_plugin/test_bandit_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the bandit tool module."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/black_tool_plugin/test_black_tool_plugin.py
+++ b/tests/plugins/tool/black_tool_plugin/test_black_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the black plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/catkin-lint_tool_plugin/test_catkin-lint_tool_plugin.py
+++ b/tests/plugins/tool/catkin-lint_tool_plugin/test_catkin-lint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the catkin_lint tool plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
+++ b/tests/plugins/tool/clang-format_tool_plugin/test_clang-format_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the clang-format plugin."""
+
 import argparse
 import os
 import shutil

--- a/tests/plugins/tool/clang-tidy_tool_plugin/test_clang-tidy_tool_plugin.py
+++ b/tests/plugins/tool/clang-tidy_tool_plugin/test_clang-tidy_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the clang-tidy plugin."""
+
 import argparse
 import os
 import subprocess
@@ -365,20 +366,12 @@ def test_clang_tidy_tool_plugin_scan_diagnosticerror(mock_subprocess_check_outpu
 def test_checkforexceptions_true():
     """Test check_for_exceptions behavior where it should return True."""
     mm = mock.MagicMock()
-    mm.group.side_effect = (
-        lambda i: "test.cpp"
-        if i == 1
-        else "google-build-using-namespace"
-        if i == 6
-        else False
+    mm.group.side_effect = lambda i: (
+        "test.cpp" if i == 1 else "google-build-using-namespace" if i == 6 else False
     )
     assert ClangTidyToolPlugin.check_for_exceptions(mm)
-    mm.group.side_effect = (
-        lambda i: "test.cc"
-        if i == 1
-        else "google-build-using-namespace"
-        if i == 6
-        else False
+    mm.group.side_effect = lambda i: (
+        "test.cc" if i == 1 else "google-build-using-namespace" if i == 6 else False
     )
     assert ClangTidyToolPlugin.check_for_exceptions(mm)
 
@@ -386,15 +379,11 @@ def test_checkforexceptions_true():
 def test_checkforexceptions_false():
     """Test check_for_exceptions behavior where it should return False."""
     mm = mock.MagicMock()
-    mm.group.side_effect = (
-        lambda i: "test.h"
-        if i == 1
-        else "google-build-using-namespace"
-        if i == 6
-        else False
+    mm.group.side_effect = lambda i: (
+        "test.h" if i == 1 else "google-build-using-namespace" if i == 6 else False
     )
     assert not ClangTidyToolPlugin.check_for_exceptions(mm)
-    mm.group.side_effect = (
-        lambda i: "test.cpp" if i == 1 else "some-other-error" if i == 6 else False
+    mm.group.side_effect = lambda i: (
+        "test.cpp" if i == 1 else "some-other-error" if i == 6 else False
     )
     assert not ClangTidyToolPlugin.check_for_exceptions(mm)

--- a/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
+++ b/tests/plugins/tool/cmakelint_tool_plugin/test_cmakelint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for cmakelint plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/cppcheck_tool_plugin/test_cppcheck_tool_plugin.py
+++ b/tests/plugins/tool/cppcheck_tool_plugin/test_cppcheck_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the cppcheck plugin."""
+
 import argparse
 import os
 import subprocess
@@ -258,8 +259,8 @@ def test_cppcheck_tool_plugin_scan_calledprocesserror(mock_subprocess_check_outp
 def test_checkforexceptions_true():
     """Test check_for_exceptions behavior where it should return True."""
     mm = mock.MagicMock()
-    mm.group.side_effect = (
-        lambda i: "test.c" if i == 1 else "variableScope" if i == 4 else False
+    mm.group.side_effect = lambda i: (
+        "test.c" if i == 1 else "variableScope" if i == 4 else False
     )
     assert CppcheckToolPlugin.check_for_exceptions(mm)
 
@@ -267,8 +268,8 @@ def test_checkforexceptions_true():
 def test_checkforexceptions_false():
     """Test check_for_exceptions behavior where it should return False."""
     mm = mock.MagicMock()
-    mm.group.side_effect = (
-        lambda i: "test.c" if i == 1 else "some-other-error" if i == 6 else False
+    mm.group.side_effect = lambda i: (
+        "test.c" if i == 1 else "some-other-error" if i == 6 else False
     )
     assert not CppcheckToolPlugin.check_for_exceptions(mm)
 

--- a/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
+++ b/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the cpplint plugin."""
+
 import argparse
 import os
 import subprocess
@@ -232,30 +233,22 @@ def test_cpplint_tool_plugin_scan_calledprocesserror(mock_subprocess_check_outpu
 def test_checkforexceptions_true():
     """Test check_for_exceptions behavior where it should return True."""
     mm = mock.MagicMock()
-    mm.group.side_effect = (
-        lambda i: "test.cpp" if i == 1 else "build/namespaces" if i == 4 else False
+    mm.group.side_effect = lambda i: (
+        "test.cpp" if i == 1 else "build/namespaces" if i == 4 else False
     )
     assert CpplintToolPlugin.check_for_exceptions(mm)
-    mm.group.side_effect = (
-        lambda i: "test.cc" if i == 1 else "build/namespaces" if i == 4 else False
+    mm.group.side_effect = lambda i: (
+        "test.cc" if i == 1 else "build/namespaces" if i == 4 else False
     )
     assert CpplintToolPlugin.check_for_exceptions(mm)
-    mm.group.side_effect = (
-        lambda i: "not-a-file"
+    mm.group.side_effect = lambda i: (
+        "not-a-file"
         if i == 1
-        else "unnamed"
-        if i == 3
-        else "build/namespaces"
-        if i == 4
-        else False
+        else "unnamed" if i == 3 else "build/namespaces" if i == 4 else False
     )
     assert CpplintToolPlugin.check_for_exceptions(mm)
-    mm.group.side_effect = (
-        lambda i: "cfg/cpp/Config.h"
-        if i == 1
-        else "build/storage_class"
-        if i == 4
-        else False
+    mm.group.side_effect = lambda i: (
+        "cfg/cpp/Config.h" if i == 1 else "build/storage_class" if i == 4 else False
     )
     assert CpplintToolPlugin.check_for_exceptions(mm)
 
@@ -263,15 +256,11 @@ def test_checkforexceptions_true():
 def test_checkforexceptions_false():
     """Test check_for_exceptions behavior where it should return False."""
     mm = mock.MagicMock()
-    mm.group.side_effect = (
-        lambda i: "test.h"
-        if i == 1
-        else "google-build-using-namespace"
-        if i == 6
-        else False
+    mm.group.side_effect = lambda i: (
+        "test.h" if i == 1 else "google-build-using-namespace" if i == 6 else False
     )
     assert not CpplintToolPlugin.check_for_exceptions(mm)
-    mm.group.side_effect = (
-        lambda i: "test.cpp" if i == 1 else "some-other-error" if i == 6 else False
+    mm.group.side_effect = lambda i: (
+        "test.cpp" if i == 1 else "some-other-error" if i == 6 else False
     )
     assert not CpplintToolPlugin.check_for_exceptions(mm)

--- a/tests/plugins/tool/do_nothing_tool_plugin/test_do_nothing_tool_plugin.py
+++ b/tests/plugins/tool/do_nothing_tool_plugin/test_do_nothing_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the do nothing tool plugin."""
+
 import os
 
 from yapsy.PluginManager import PluginManager

--- a/tests/plugins/tool/docformatter_tool_plugin/test_docformatter_tool_plugin.py
+++ b/tests/plugins/tool/docformatter_tool_plugin/test_docformatter_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the docformatter plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/docformatter_tool_plugin/valid_package/wrong.py
+++ b/tests/plugins/tool/docformatter_tool_plugin/valid_package/wrong.py
@@ -1,4 +1,5 @@
-'''
+"""
 Docstring with single quotes instead of double quotes.
-'''
+"""
+
 my_str = "not an int"

--- a/tests/plugins/tool/flawfinder_tool_plugin/test_flawfinder_tool_plugin.py
+++ b/tests/plugins/tool/flawfinder_tool_plugin/test_flawfinder_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the flawfinder plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/groovylint_tool_plugin/test_groovylint_tool_plugin.py
+++ b/tests/plugins/tool/groovylint_tool_plugin/test_groovylint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the groovylint plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/groovylint_tool_plugin/test_groovylint_tool_plugin.py
+++ b/tests/plugins/tool/groovylint_tool_plugin/test_groovylint_tool_plugin.py
@@ -125,6 +125,17 @@ def test_groovylint_tool_plugin_parse_invalid():
     assert not issues
 
 
+def test_groovylint_tool_plugin_parse_no_summary():
+    """Test what happens when input has no summary.
+
+    Expected result: no issues found
+    """
+    plugin = setup_groovylint_tool_plugin()
+    output = '{"nothing_we_parse":{"totalFilesWithErrorsNumber":1}}'
+    issues = plugin.parse_output([output])
+    assert not issues
+
+
 @mock.patch("statick_tool.plugins.tool.groovylint_tool_plugin.subprocess.check_output")
 def test_groovylint_tool_plugin_scan_calledprocesserror(mock_subprocess_check_output):
     """Test what happens when a CalledProcessError is raised (usually means groovylint

--- a/tests/plugins/tool/isort_tool_plugin/test_isort_tool_plugin.py
+++ b/tests/plugins/tool/isort_tool_plugin/test_isort_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the isort plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/isort_tool_plugin/valid_package/whitespace.py
+++ b/tests/plugins/tool/isort_tool_plugin/valid_package/whitespace.py
@@ -1,4 +1,4 @@
 """Sample file with imports not correctly sorted."""
 
-import logging # comment
+import logging  # comment
 import re

--- a/tests/plugins/tool/lizard_tool_plugin/test_lizard_tool_plugin.py
+++ b/tests/plugins/tool/lizard_tool_plugin/test_lizard_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the lizard plugin."""
+
 import argparse
 import os
 

--- a/tests/plugins/tool/make_tool_plugin/test_make_tool_plugin.py
+++ b/tests/plugins/tool/make_tool_plugin/test_make_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the make tool plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/mypy_tool_plugin/test_mypy_tool_plugin.py
+++ b/tests/plugins/tool/mypy_tool_plugin/test_mypy_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the mypy plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/perlcritic_tool_plugin/test_perlcritic_tool_plugin.py
+++ b/tests/plugins/tool/perlcritic_tool_plugin/test_perlcritic_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the perlcritic plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/pycodestyle_tool_plugin/test_pycodestyle_tool_plugin.py
+++ b/tests/plugins/tool/pycodestyle_tool_plugin/test_pycodestyle_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the pycodestyle plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/pydocstyle_tool_plugin/test_pydocstyle_tool_plugin.py
+++ b/tests/plugins/tool/pydocstyle_tool_plugin/test_pydocstyle_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the PyCodeStyle plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/pyflakes_tool_plugin/test_pyflakes_tool_plugin.py
+++ b/tests/plugins/tool/pyflakes_tool_plugin/test_pyflakes_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Pyflakes plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/pylint_tool_plugin/test_pylint_tool_plugin.py
+++ b/tests/plugins/tool/pylint_tool_plugin/test_pylint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Pylint tool plugin."""
+
 import argparse
 import multiprocessing
 import os

--- a/tests/plugins/tool/ruff_tool_plugin/test_ruff_tool_plugin.py
+++ b/tests/plugins/tool/ruff_tool_plugin/test_ruff_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the ruff plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/ruff_tool_plugin/valid_package/ruff_test.py
+++ b/tests/plugins/tool/ruff_tool_plugin/valid_package/ruff_test.py
@@ -3,4 +3,8 @@ try:
 except ImportError:
     from django.utils import simplejson as json  # NOQA
 
+# Need to create an unused import to generate a ruff error.
+import os
+
+# Line too long does not trigger going from ruff v0.0.278 to v0.1.1.
 some_long_variable = "make this string go past the allowed length of 88 characters by adding ridiculous redundancy"

--- a/tests/plugins/tool/shellcheck_tool_plugin/test_shellcheck_tool_plugin.py
+++ b/tests/plugins/tool/shellcheck_tool_plugin/test_shellcheck_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the Shellcheck tool plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/spotbugs_tool_plugin/test_spotbugs_tool_plugin.py
+++ b/tests/plugins/tool/spotbugs_tool_plugin/test_spotbugs_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the spotbugs plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/uncrustify_tool_plugin/test_uncrustify_tool_plugin.py
+++ b/tests/plugins/tool/uncrustify_tool_plugin/test_uncrustify_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the uncrustify plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/xmllint_tool_plugin/test_xmllint_tool_plugin.py
+++ b/tests/plugins/tool/xmllint_tool_plugin/test_xmllint_tool_plugin.py
@@ -1,4 +1,5 @@
 """xmllint unit tests."""
+
 import argparse
 import os
 import subprocess

--- a/tests/plugins/tool/yamllint_tool_plugin/test_yamllint_tool_plugin.py
+++ b/tests/plugins/tool/yamllint_tool_plugin/test_yamllint_tool_plugin.py
@@ -1,4 +1,5 @@
 """Unit tests for the YAMLLint tool plugin."""
+
 import argparse
 import os
 import subprocess

--- a/tests/profile/test_profile.py
+++ b/tests/profile/test_profile.py
@@ -1,4 +1,5 @@
 """Unit tests for the Args module."""
+
 import os
 
 import pytest

--- a/tests/reporting_plugin/test_reporting_plugin.py
+++ b/tests/reporting_plugin/test_reporting_plugin.py
@@ -1,4 +1,5 @@
 """Tests for statick_tool.reporting_plugin."""
+
 import argparse
 import os
 

--- a/tests/tool_plugin/test_tool_plugin.py
+++ b/tests/tool_plugin/test_tool_plugin.py
@@ -1,4 +1,5 @@
 """Tests for statick_tool.tool_plugin."""
+
 import argparse
 import os
 import stat

--- a/tox.ini
+++ b/tox.ini
@@ -48,9 +48,7 @@ deps =
     pytest-isort
     .[test]
 commands =
-    pydocstyle ../statick_tool/
-    pycodestyle --ignore=E203,E501,W503 ../statick_tool/
-    pytest --flake8 --isort \
+    pytest \
         --cov={toxinidir}/statick_tool \
         --cov-report term-missing \
         --doctest-modules \


### PR DESCRIPTION
Black and npm-groovy-lint have newer versions available. Using those newer versions cause issues with tool plugin performance, unit tests and formatting.

- Install lark as test dependency.
- Run groovylint tool against all source files at once instead of one at a time.
- Handle parsing issues when CodeNarcServer errors are present in npm-groovy-lint output.
- Add groovylint unit test for potential errors in tool output.
- Black formatting all source code with v24.1.1.