### PR TITLE
Add short flag names

### DIFF
--- a/statick_tool/args.py
+++ b/statick_tool/args.py
@@ -24,10 +24,10 @@ class Args:
             "help": "Comma separated list of paths containing "
             "configuration or plugins",
         }
-        self.pre_parser.add_argument("--user-paths", **user_path_args)  # type: ignore
+        self.pre_parser.add_argument("--user-paths", "-u", **user_path_args)  # type: ignore
 
         self.parser = argparse.ArgumentParser(description=name)
-        self.parser.add_argument("--user-paths", **user_path_args)  # type: ignore
+        self.parser.add_argument("--user-paths", "-u", **user_path_args)  # type: ignore
 
     def get_user_paths(self, args: Any = None) -> List[str]:
         """Get a list of user paths containing config or plugins."""

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -192,7 +192,7 @@ class Statick:  # pylint: disable=too-many-instance-attributes
             help="Force only the given list of tools to run",
         )
         args.add_argument(
-            "--version", "-v",
+            "--version",
             action="version",
             version=f"%(prog)s {__version__}",
         )

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -146,7 +146,8 @@ class Statick:  # pylint: disable=too-many-instance-attributes
     def gather_args(self, args: argparse.ArgumentParser) -> None:
         """Gather arguments."""
         args.add_argument(
-            "--output-directory", "-o",
+            "--output-directory",
+            "-o",
             dest="output_directory",
             type=str,
             help="Directory to write output files to",

--- a/statick_tool/statick.py
+++ b/statick_tool/statick.py
@@ -146,7 +146,7 @@ class Statick:  # pylint: disable=too-many-instance-attributes
     def gather_args(self, args: argparse.ArgumentParser) -> None:
         """Gather arguments."""
         args.add_argument(
-            "--output-directory",
+            "--output-directory", "-o",
             dest="output_directory",
             type=str,
             help="Directory to write output files to",
@@ -192,7 +192,7 @@ class Statick:  # pylint: disable=too-many-instance-attributes
             help="Force only the given list of tools to run",
         )
         args.add_argument(
-            "--version",
+            "--version", "-v",
             action="version",
             version=f"%(prog)s {__version__}",
         )

--- a/tests/plugins/tool/black_tool_plugin/valid_package/format_errors.py
+++ b/tests/plugins/tool/black_tool_plugin/valid_package/format_errors.py
@@ -1,1 +1,1 @@
-x =  "some string",
+x = ("some string",)

--- a/tests/plugins/tool/black_tool_plugin/valid_package/format_errors.py
+++ b/tests/plugins/tool/black_tool_plugin/valid_package/format_errors.py
@@ -1,1 +1,1 @@
-x = ("some string",)
+x = "some string",

--- a/tests/plugins/tool/black_tool_plugin/valid_package/format_errors.py
+++ b/tests/plugins/tool/black_tool_plugin/valid_package/format_errors.py
@@ -1,1 +1,1 @@
-x = "some string",
+x =  "some string",


### PR DESCRIPTION
Added short flags "--output-drectory" as "-o" and "--user-paths" as "-u". Optest and black formatting ran successfully. 