### PR TITLE
Fix unit test and type hints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Removed support for Python 3.8.
   - Fixed unit tests for groovylint tool plugin.
   - Handle parsing issues when CodeNarcServer errors are present.
   - Update source file formatting with latest version of black.
+  - Cpplint unit test updated to match new default warnings from the cpplint 2.0 release.
+    - Cpplint 2.0 released on 2024-10-06.
+    - <https://github.com/cpplint/cpplint/blob/2.0.0/CHANGELOG.rst#20-2024-10-06>
 - Fix command used to run ruff tool.
   - Ruff v0.5.0 requires use of `ruff check` instead of `ruff`.
 - Update list of files in clean script to fix shellscript warnings about globs for files with hyphens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Removed support for Python 3.8.
 - Update list of files in clean script to fix shellscript warnings about globs for files with hyphens.
 - Ignore new pylint finding for too many positional arguments.
   Finding showed up with pylint 3.3.0.
+- Change default value of deep get method to match valid type for reduce function.
 
 ## v0.9.4 - 2022-04-25
 

--- a/statick_tool/plugins/discovery/ros_discovery_plugin.py
+++ b/statick_tool/plugins/discovery/ros_discovery_plugin.py
@@ -24,7 +24,7 @@ class RosDiscoveryPlugin(DiscoveryPlugin):
         cls,
         dictionary: Union[str, Dict[Any, str]],
         keys: str,
-        default: Optional[str] = None,
+        default: str = "",
     ) -> Any:
         """Safe way to check for a value in a nested dict.
 

--- a/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
+++ b/tests/plugins/tool/cpplint_tool_plugin/test_cpplint_tool_plugin.py
@@ -106,8 +106,7 @@ def test_cpplint_tool_plugin_scan_valid():
         package["headers"] = []
         package["cpplint"] = "cpplint"
         issues = ctp.scan(package, "level")
-    print(f"Line: {issues[2].message}")
-    assert len(issues) == 4
+    assert len(issues) == 5
     assert issues[2].filename == os.path.join(
         os.path.dirname(__file__), "valid_package", "test.c"
     )


### PR DESCRIPTION
* Update cpplint unit test to match default warnings in latest major version release.
* Change default value of deep get method to match valid type for reduce function.